### PR TITLE
feat: add soft validation and 3.1 support

### DIFF
--- a/packages/openapi-to-graphql/README.md
+++ b/packages/openapi-to-graphql/README.md
@@ -21,7 +21,7 @@ Note that [`GraphQL.js`](https://github.com/graphql/graphql-js) is a [peer depen
 
 ## Usage
 
-The basic way to use OpenAPI-to-GraphQL is to pass an OpenAPI Specification (OAS; version 2.0 or 3.0.x) to the `generateGraphQLSchema` function. The function returns a promise that resolves on an object containing the generated GraphQL schema as well as a report about possible issues when generating the schema:
+The basic way to use OpenAPI-to-GraphQL is to pass an OpenAPI Specification (OAS; version 2.0, 3.0.x or 3.1) to the `generateGraphQLSchema` function. The function returns a promise that resolves on an object containing the generated GraphQL schema as well as a report about possible issues when generating the schema:
 
 ```javascript
 const { createGraphQLSchema } = require('openapi-to-graphql')
@@ -146,6 +146,7 @@ createGraphQLSchema(oas[, options])
 The options object can contain the following properties:
 
 - `strict` (type: `boolean`, default: `false`): OpenAPI-to-GraphQL generally tries to produce a working GraphQL schema for a given OAS if the strict mode is disabled. If OpenAPI-to-GraphQL cannot fully translate a given OAS (e.g., because data schema definitions are incomplete or there are name collusions that cannot be resolved), `createGraphQLSchema` will by default degrade gracefully and produce a partial GraphQL schema. OpenAPI-to-GraphQL will log warnings (given logging is enabled). If the `strict` mode is enabled, however, `createGraphQLSchema` will throw an error if it cannot create a GraphQL schema matching the given OAS perfectly.
+- `softValidation` (type: `boolean`, default: `false`): OpenAPI-to-GraphQL will by default validate the given OAS before creating a GraphQL schema. If the `softValidation` mode is enabled, however, `createGraphQLSchema` will not validate the given OAS before creating a GraphQL schema. This is useful if you want to create a GraphQL schema for an OAS that is not fully compliant with the OpenAPI Specification. Errors will be added to the report object.
 
 ***
 
@@ -203,7 +204,7 @@ Authentication options:
 
 Validation options:
 
-- `oasValidatorOptions` (type: `object`, default: `{}`): We use the [oas-validator](https://www.npmjs.com/package/oas-validator) library to validate Swaggers/OASs. We expose the options so that users can have more control over validation. See [here](https://github.com/Mermade/oas-kit/blob/master/docs/options.md) for more information.
+- `oasValidatorOptions` (type: `object`, default: `{}`): We use the [@readme/openapi-parser](https://www.npmjs.com/package/@readme/openapi-parser) library to validate Swaggers/OASs. We expose the options so that users can have more control over validation. See [here](https://apitools.dev/swagger-parser/docs/options.html) for more information.
 
 - `swagger2OpenAPIOptions` (type: `object`, default: `{}`): We use the [swagger2openapi](https://www.npmjs.com/package/swagger2openapi) library to validate Swaggers/OASs. We expose the options so that users can have more control over validation. See [here](https://github.com/Mermade/oas-kit/blob/master/docs/options.md) for more information.
 

--- a/packages/openapi-to-graphql/package.json
+++ b/packages/openapi-to-graphql/package.json
@@ -81,6 +81,7 @@
     "testRegex": "/test/.*\\.test\\.(ts|tsx|js)$"
   },
   "dependencies": {
+    "@readme/openapi-parser": "^2.5.0",
     "cross-fetch": "^3.1.4",
     "debug": "^4.2.0",
     "deep-equal": "^2.0.5",

--- a/packages/openapi-to-graphql/src/index.ts
+++ b/packages/openapi-to-graphql/src/index.ts
@@ -52,7 +52,7 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLOutputType,
-  GraphQLFieldConfig,
+  GraphQLFieldConfig
 } from 'graphql'
 
 // Imports:
@@ -133,7 +133,11 @@ const DEFAULT_OPTIONS: InternalOptions<any, any, any> = {
 /**
  * Creates a GraphQL interface from the given OpenAPI Specification (2 or 3).
  */
-export async function createGraphQLSchema<TSource, TContext, TArgs extends object>(
+export async function createGraphQLSchema<
+  TSource,
+  TContext,
+  TArgs extends object
+>(
   spec: Oas3 | Oas2 | (Oas3 | Oas2)[],
   options?: Options<TSource, TContext, TArgs>
 ): Promise<Result<TSource, TContext, TArgs>> {
@@ -150,7 +154,8 @@ export async function createGraphQLSchema<TSource, TContext, TArgs extends objec
         Oas3Tools.getValidOAS3(
           ele,
           internalOptions.oasValidatorOptions,
-          internalOptions.swagger2OpenAPIOptions
+          internalOptions.swagger2OpenAPIOptions,
+          internalOptions.softValidation
         )
       )
     )
@@ -164,7 +169,8 @@ export async function createGraphQLSchema<TSource, TContext, TArgs extends objec
     const oas = await Oas3Tools.getValidOAS3(
       spec,
       internalOptions.oasValidatorOptions,
-      internalOptions.swagger2OpenAPIOptions
+      internalOptions.swagger2OpenAPIOptions,
+      internalOptions.softValidation
     )
     return translateOpenAPIToGraphQL([oas], internalOptions)
   }
@@ -173,7 +179,11 @@ export async function createGraphQLSchema<TSource, TContext, TArgs extends objec
 /**
  * Creates a GraphQL interface from the given OpenAPI Specification 3
  */
-export function translateOpenAPIToGraphQL<TSource, TContext, TArgs extends object>(
+export async function translateOpenAPIToGraphQL<
+  TSource,
+  TContext,
+  TArgs extends object
+>(
   oass: Oas3[],
   {
     strict,
@@ -216,7 +226,7 @@ export function translateOpenAPIToGraphQL<TSource, TContext, TArgs extends objec
 
     fetch
   }: InternalOptions<TSource, TContext, TArgs>
-): Result<TSource, TContext, TArgs> {
+): Promise<Result<TSource, TContext, TArgs>> {
   const options = {
     strict,
     report,
@@ -264,7 +274,7 @@ export function translateOpenAPIToGraphQL<TSource, TContext, TArgs extends objec
    * Extract information from the OASs and put it inside a data structure that
    * is easier for OpenAPI-to-GraphQL to use
    */
-  const data: PreprocessingData<TSource, TContext, TArgs> = preprocessOas(
+  const data: PreprocessingData<TSource, TContext, TArgs> = await preprocessOas(
     oass,
     options
   )
@@ -481,7 +491,7 @@ function addQueryFields<TSource, TContext, TArgs extends object>({
     singularNames,
     baseUrl,
     requestOptions,
-      fileUploadOptions,
+    fileUploadOptions,
     connectOptions,
     fetch
   } = options
@@ -660,7 +670,7 @@ function addMutationFields<TSource, TContext, TArgs extends object>({
     singularNames,
     baseUrl,
     requestOptions,
-      fileUploadOptions,
+    fileUploadOptions,
     connectOptions,
     fetch
   } = options
@@ -810,7 +820,8 @@ function addSubscriptionFields<TSource, TContext, TArgs extends object>({
   options: InternalOptions<TSource, TContext, TArgs>
   data: PreprocessingData<TSource, TContext, TArgs>
 }) {
-  const { baseUrl, requestOptions, connectOptions, fetch, fileUploadOptions } = options
+  const { baseUrl, requestOptions, connectOptions, fetch, fileUploadOptions } =
+    options
 
   const field = getFieldForOperation(
     operation,

--- a/packages/openapi-to-graphql/src/types/oas3.ts
+++ b/packages/openapi-to-graphql/src/types/oas3.ts
@@ -12,9 +12,16 @@ type ExternalDocumentationObject = {
   url: string
 }
 
+type SchemaObjectType =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'object'
+  | 'array'
 export type SchemaObject = {
   title?: string
-  type?: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'
+  type?: SchemaObjectType | [SchemaObjectType, null]
   format?: string
   nullable?: boolean
   description?: string

--- a/packages/openapi-to-graphql/src/types/options.ts
+++ b/packages/openapi-to-graphql/src/types/options.ts
@@ -20,6 +20,7 @@ export type Warning = {
 }
 
 export type Report = {
+  validationErrors?: string[]
   warnings: Warning[]
   numOps: number
   numOpsQuery: number
@@ -335,6 +336,13 @@ export type InternalOptions<TSource, TContext, TArgs> = {
    */
   swagger2OpenAPIOptions: object
 
+  /**
+   * Determines how to perform validation of the OAS. If set to true, the
+   * process will throw an error and stop execution. If set to false, the
+   * process will return the error in the response and continue execution.
+   */
+  softValidation?: boolean
+
   // Logging options
 
   /**
@@ -346,6 +354,7 @@ export type InternalOptions<TSource, TContext, TArgs> = {
    *
    * This option prevents the extensions from being created.
    */
+
   provideErrorExtensions: boolean
 
   /**

--- a/packages/openapi-to-graphql/test/fixtures/petstore31.json
+++ b/packages/openapi-to-graphql/test/fixtures/petstore31.json
@@ -1,0 +1,166 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": ["pets"],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": ["pets"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/openapi-to-graphql/test/fixtures/trello.json
+++ b/packages/openapi-to-graphql/test/fixtures/trello.json
@@ -1,0 +1,12119 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Trello REST API", "version": "0.0.1" },
+  "servers": [{ "url": "https://api.trello.com/1" }],
+  "components": {
+    "securitySchemes": {
+      "APIKey": { "type": "apiKey", "in": "query", "name": "key" },
+      "APIToken": { "in": "query", "name": "token", "type": "apiKey" }
+    },
+    "schemas": {
+      "posStringOrNumber": {
+        "oneOf": [
+          { "type": "string", "enum": ["top", "bottom"] },
+          { "type": "number", "format": "float", "example": 1293.5 }
+        ]
+      },
+      "APIKey": {
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{32}$",
+        "example": "0471642aefef5fa1fa76530ce1ba4c85"
+      },
+      "APIToken": {
+        "type": "string",
+        "example": "9eb76d9a9d02b8dd40c2f3e5df18556c831d4d1fadbe2c45f8310e6c93b5c548"
+      },
+      "ActionFields": {
+        "type": "string",
+        "enum": [
+          "id",
+          "idMemberCreator",
+          "data",
+          "type",
+          "date",
+          "limits",
+          "display",
+          "memberCreator"
+        ]
+      },
+      "Action": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "$ref": "#/components/schemas/TrelloID" },
+          "idMemberCreator": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "example": "Can never go wrong with bowie"
+              },
+              "card": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "$ref": "#/components/schemas/TrelloID"
+                  },
+                  "name": { "type": "string", "example": "Bowie" },
+                  "idShort": { "type": "integer", "example": 7 },
+                  "shortLink": { "type": "string", "example": "3CsPkqOF" }
+                }
+              },
+              "board": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "$ref": "#/components/schemas/TrelloID"
+                  },
+                  "name": { "type": "string", "example": "Mullets" },
+                  "shortLink": { "type": "string", "example": "3CsPkqOF" }
+                }
+              },
+              "list": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "$ref": "#/components/schemas/TrelloID"
+                  },
+                  "name": { "type": "string", "example": "Amazing" }
+                }
+              }
+            }
+          },
+          "type": { "type": "string", "example": "commentCard" },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2020-03-09T19:41:51.396Z"
+          },
+          "limits": {
+            "type": "object",
+            "properties": {
+              "reactions": {
+                "type": "object",
+                "properties": {
+                  "perAction": {
+                    "type": "object",
+                    "properties": {
+                      "status": { "type": "string", "example": "ok" },
+                      "disableAt": { "type": "number", "example": 1000 },
+                      "warnAt": { "type": "number", "example": 900 }
+                    }
+                  },
+                  "uniquePerAction": {
+                    "type": "object",
+                    "properties": {
+                      "status": { "type": "string", "example": "ok" },
+                      "disableAt": { "type": "number", "example": 1000 },
+                      "warnAt": { "type": "number", "example": 900 }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "display": {
+            "type": "object",
+            "properties": {
+              "translationKey": {
+                "type": "string",
+                "example": "action_comment_on_card"
+              },
+              "entities": {
+                "type": "object",
+                "properties": {
+                  "contextOn": {
+                    "type": "object",
+                    "properties": {
+                      "type": { "type": "string", "example": "translatable" },
+                      "translationKey": {
+                        "type": "string",
+                        "example": "action_on"
+                      },
+                      "hideIfContext": { "type": "boolean" },
+                      "idContext": {
+                        "type": "string",
+                        "$ref": "#/components/schemas/TrelloID"
+                      }
+                    }
+                  },
+                  "card": {
+                    "type": "object",
+                    "properties": {
+                      "type": { "type": "string", "example": "card" },
+                      "hideIfContext": { "type": "boolean" },
+                      "id": {
+                        "type": "string",
+                        "$ref": "#/components/schemas/TrelloID"
+                      },
+                      "shortLink": { "type": "string", "example": "3CsPkqOF" },
+                      "text": { "type": "string", "example": "Bowie" }
+                    }
+                  },
+                  "comment": {
+                    "type": "object",
+                    "properties": {
+                      "type": { "type": "string", "example": "comment" },
+                      "text": {
+                        "type": "string",
+                        "example": "Can never go wrong with bowie"
+                      }
+                    }
+                  },
+                  "memberCreator": {
+                    "type": "object",
+                    "properties": {
+                      "type": { "type": "string", "example": "member" },
+                      "id": { "$ref": "#/components/schemas/TrelloID" },
+                      "username": { "type": "string", "example": "bobloblaw" },
+                      "text": {
+                        "type": "string",
+                        "example": "Bob Loblaw (World)"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "memberCreator": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "5b02e7f4e1facdc393169f9d"
+              },
+              "activityBlocked": { "type": "boolean", "example": false },
+              "avatarHash": {
+                "type": "string",
+                "example": "db2adf80c2e6c26b76e1f10400eb4c45"
+              },
+              "avatarUrl": {
+                "type": "string",
+                "format": "url",
+                "example": "https://trello-members.s3.amazonaws.com/5b02e7f4e1facdc393169f9d/db2adf80c2e6c26b76e1f10400eb4c45"
+              },
+              "fullName": {
+                "type": "string",
+                "example": "Bob Loblaw (Trello)"
+              },
+              "idMemberReferrer": {
+                "type": "string",
+                "$ref": "#/components/schemas/TrelloID",
+                "nullable": true,
+                "example": null
+              },
+              "initials": { "type": "string", "example": "BL" },
+              "username": { "type": "string", "example": "bobloblaw" }
+            }
+          }
+        }
+      },
+      "AttachmentFields": {
+        "type": "string",
+        "enum": [
+          "id",
+          "bytes",
+          "date",
+          "edgeColor",
+          "idMember",
+          "isUpload",
+          "mimeType",
+          "name",
+          "previews",
+          "url",
+          "pos"
+        ]
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5bc79d4206526d2279c1e6ea"
+          },
+          "bytes": { "type": "string", "example": null, "nullable": true },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "example": "2018-10-17T19:10:14.808Z"
+          },
+          "edgeColor": {
+            "type": "string",
+            "$ref": "#/components/schemas/Color",
+            "example": null,
+            "nullable": true
+          },
+          "idMember": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5bc79d4206526d2279c1e6eb"
+          },
+          "isUpload": { "type": "boolean", "example": false },
+          "mimeType": { "type": "string", "example": "" },
+          "name": {
+            "type": "string",
+            "example": "Deprecation Extension Notice"
+          },
+          "previews": {
+            "type": "array",
+            "items": { "type": "string" },
+            "example": []
+          },
+          "url": {
+            "type": "string",
+            "format": "url",
+            "example": "https://admin.typeform.com/form/RzExEM/share#/link"
+          },
+          "pos": { "type": "number", "format": "float", "example": 1638 }
+        }
+      },
+      "BlockedKey": {
+        "type": "string",
+        "enum": [
+          "notification_comment_card",
+          "notification_added_a_due_date",
+          "notification_changed_due_date",
+          "notification_card_due_soon",
+          "notification_removed_from_card",
+          "notification_added_attachment_to_card",
+          "notification_created_card",
+          "notification_moved_card",
+          "notification_archived_card",
+          "notification_unarchived_card"
+        ],
+        "example": "notification_comment_card"
+      },
+      "BoardFields": {
+        "type": "string",
+        "enum": [
+          "id",
+          "name",
+          "desc",
+          "descData",
+          "closed",
+          "idMemberCreator",
+          "idOrganization",
+          "pinned",
+          "url",
+          "shortUrl",
+          "prefs",
+          "labelNames",
+          "starred",
+          "limits",
+          "memberships",
+          "enterpriseOwned"
+        ]
+      },
+      "Board": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "name": {
+            "type": "string",
+            "description": "The name of the board.",
+            "example": "Trello Platform Changes"
+          },
+          "desc": {
+            "type": "string",
+            "example": "Track changes to Trello's Platform on this board."
+          },
+          "descData": { "type": "string" },
+          "closed": { "type": "boolean", "example": false },
+          "idMemberCreator": { "$ref": "#/components/schemas/TrelloID" },
+          "idOrganization": { "$ref": "#/components/schemas/TrelloID" },
+          "pinned": { "type": "boolean", "example": false },
+          "url": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello.com/b/dQHqCohZ/trello-platform-changelog"
+          },
+          "shortUrl": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello.com/b/dQHqCohZ"
+          },
+          "prefs": { "$ref": "#/components/schemas/Prefs" },
+          "labelNames": {
+            "type": "object",
+            "properties": {
+              "green": { "type": "string", "example": "Addition" },
+              "yellow": { "type": "string", "example": "Update" },
+              "orange": { "type": "string", "example": "Deprecation" },
+              "red": { "type": "string", "example": "Deletion" },
+              "purple": { "type": "string", "example": "Power-Ups" },
+              "blue": { "type": "string", "example": "News" },
+              "sky": { "type": "string", "example": "Announcement" },
+              "lime": { "type": "string", "example": "Delight" },
+              "pink": { "type": "string", "example": "REST API" },
+              "black": { "type": "string", "example": "Capabilties" }
+            }
+          },
+          "limits": { "type": "object", "$ref": "#/components/schemas/Limits" },
+          "starred": { "type": "boolean" },
+          "memberships": { "type": "string" },
+          "shortLink": { "type": "string" },
+          "subscribed": { "type": "boolean" },
+          "powerUps": { "type": "string" },
+          "dateLastActivity": { "type": "string", "format": "date" },
+          "dateLastView": { "type": "string", "format": "date" },
+          "idTags": { "type": "string" },
+          "datePluginDisable": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "creationMethod": { "type": "string", "nullable": true },
+          "ixUpdate": { "type": "integer" },
+          "templateGallery": { "type": "string", "nullable": true },
+          "enterpriseOwned": { "type": "boolean" }
+        }
+      },
+      "BoardBackground": {
+        "type": "object",
+        "properties": { "id": { "$ref": "#/components/schemas/TrelloID" } }
+      },
+      "BoardStars": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "585063850027165010be15a8"
+          },
+          "idBoard": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "57f7df684f1ca8c2877162e0"
+          },
+          "pos": { "type": "integer", "example": 32768 }
+        }
+      },
+      "Channel": { "type": "string", "enum": ["email"], "example": "email" },
+      "CheckItem": {
+        "type": "object",
+        "properties": {
+          "idChecklist": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5dc9b507756e182c76007621"
+          },
+          "state": {
+            "type": "string",
+            "enum": ["complete", "incomplete"],
+            "example": "incomplete"
+          },
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5dc9b509f02f4314edc4303a"
+          },
+          "name": { "type": "string" },
+          "nameData": { "type": "string", "nullable": true, "example": null },
+          "pos": { "type": "string", "example": 1673 }
+        }
+      },
+      "Checklist": {
+        "type": "object",
+        "properties": { "id": { "$ref": "#/components/schemas/TrelloID" } }
+      },
+      "Card": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "address": { "type": "string", "nullable": true },
+          "badges": {
+            "type": "object",
+            "properties": {
+              "attachmentsByType": {
+                "type": "object",
+                "properties": {
+                  "trello": {
+                    "type": "object",
+                    "properties": {
+                      "board": { "type": "number" },
+                      "card": { "type": "number" }
+                    }
+                  }
+                }
+              },
+              "location": { "type": "boolean" },
+              "votes": { "type": "integer" },
+              "viewingMemberVoted": { "type": "boolean", "example": false },
+              "subscribed": { "type": "boolean", "example": false },
+              "fogbugz": { "type": "string" },
+              "checkItems": { "type": "integer", "example": 0 },
+              "checkItemsChecked": { "type": "integer", "example": 0 },
+              "comments": { "type": "integer", "example": 0 },
+              "attachments": { "type": "integer", "example": 0 },
+              "description": { "type": "boolean" },
+              "due": { "type": "string", "format": "date", "nullable": true },
+              "start": { "type": "string", "format": "date", "nullable": true },
+              "dueComplete": { "type": "boolean" }
+            }
+          },
+          "checkItemStates": {
+            "type": "array",
+            "items": { "oneOf": [{ "type": "string" }] }
+          },
+          "closed": { "type": "boolean" },
+          "coordinates": { "type": "string", "nullable": true },
+          "creationMethod": { "type": "string", "nullable": true },
+          "dateLastActivity": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2019-09-16T16:19:17.156Z"
+          },
+          "desc": {
+            "type": "string",
+            "example": "👋Hey there,\n\nTrello's Platform team uses this board to keep developers up-to-date."
+          },
+          "descData": {
+            "type": "object",
+            "properties": { "emoji": { "type": "object" } }
+          },
+          "due": { "type": "string", "format": "date", "nullable": true },
+          "dueReminder": { "type": "string", "nullable": true },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "bentleycook+2kea95u7kchsvqnxkwe+2q0byi6qv4pt9uc7q5m+25qyyohtzg@boards.trello.com"
+          },
+          "idBoard": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5abbe4b7ddc1b351ef961414"
+          },
+          "idChecklists": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/Checklist" },
+                { "$ref": "#/components/schemas/TrelloID" }
+              ]
+            }
+          },
+          "idLabels": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/Label" },
+                { "$ref": "#/components/schemas/TrelloID" }
+              ]
+            }
+          },
+          "idList": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5abbe4b7ddc1b351ef961415"
+          },
+          "idMembers": {
+            "type": "array",
+            "items": { "oneOf": [{ "$ref": "#/components/schemas/TrelloID" }] }
+          },
+          "idMembersVoted": {
+            "type": "array",
+            "items": { "oneOf": [{ "$ref": "#/components/schemas/TrelloID" }] }
+          },
+          "idShort": { "type": "integer" },
+          "idAttachmentCover": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5abbe4b7ddc1b351ef961415",
+            "nullable": true
+          },
+          "labels": {
+            "type": "array",
+            "items": { "oneOf": [{ "$ref": "#/components/schemas/TrelloID" }] }
+          },
+          "limits": { "type": "object", "$ref": "#/components/schemas/Limits" },
+          "locationName": { "type": "string", "nullable": true },
+          "manualCoverAttachment": { "type": "boolean", "example": false },
+          "name": { "type": "string", "example": "👋 What? Why? How?" },
+          "pos": { "type": "number", "format": "float", "example": 65535 },
+          "shortLink": { "type": "string", "example": "H0TZyzbK" },
+          "shortUrl": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello.com/c/H0TZyzbK"
+          },
+          "subscribed": { "type": "boolean", "example": false },
+          "url": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello.com/c/H0TZyzbK/4-%F0%9F%91%8B-what-why-how"
+          },
+          "cover": {
+            "type": "object",
+            "properties": {
+              "idAttachment": {
+                "type": "string",
+                "$ref": "#/components/schemas/TrelloID",
+                "nullable": true
+              },
+              "color": {
+                "$ref": "#/components/schemas/Color",
+                "nullable": true
+              },
+              "idUploadedBackground": { "type": "boolean", "nullable": true },
+              "size": { "type": "string", "enum": ["normal"] },
+              "brightness": { "type": "string", "enum": ["light", "dark"] },
+              "isTemplate": { "type": "boolean", "example": false }
+            }
+          }
+        }
+      },
+      "CardFields": {
+        "type": "string",
+        "enum": [
+          "id",
+          "address",
+          "badges",
+          "checkItemStates",
+          "closed",
+          "coordinates",
+          "creationMethod",
+          "dueComplete",
+          "dateLastActivity",
+          "desc",
+          "descData",
+          "due",
+          "dueReminder",
+          "email",
+          "idBoard",
+          "idChecklists",
+          "idLabels",
+          "idList",
+          "idMembers",
+          "idMembersVoted",
+          "idShort",
+          "idAttachmentCover",
+          "labels",
+          "limits",
+          "locationName",
+          "manualCoverAttachment",
+          "name",
+          "pos",
+          "shortLink",
+          "shortUrl",
+          "subscribed",
+          "url",
+          "cover",
+          "isTemplate"
+        ],
+        "description": "The fields on a Card."
+      },
+      "ClaimableOrganizations": {
+        "type": "object",
+        "properties": {
+          "organizations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string", "example": "organization_name" },
+                "displayName": {
+                  "type": "string",
+                  "example": "Organization Name"
+                },
+                "activeMembershipCount": { "type": "number", "example": 5 },
+                "idActiveAdmins": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/TrelloID" }
+                },
+                "products": {
+                  "type": "array",
+                  "items": { "type": "number", "format": "integer" }
+                },
+                "id": {
+                  "type": "string",
+                  "$ref": "#/components/schemas/TrelloID",
+                  "example": "617abd5995eae45169a11059"
+                },
+                "logoUrl": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": null
+                },
+                "dateLastActive": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "2019-08-22T18:15:53.546Z",
+                  "format": "date",
+                  "description": "The date of the most recent activity on any of the boards in the workspace. If the workspace has no boards, or the boards have no activity, this value will be null."
+                }
+              }
+            }
+          },
+          "claimableCount": { "type": "number", "example": 2 }
+        }
+      },
+      "CustomEmoji": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5900ac11ed55d6d2c355c5d6"
+          },
+          "url": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello-emoji.s3.amazonaws.com/5589c3ea49b40cedc28cf70e/b40d9925f4e75495104b5e560881d8e4/chorizo.png"
+          },
+          "name": { "type": "string", "example": "chorizo" }
+        }
+      },
+      "CustomField": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5ab10be237846c43015f108e"
+          },
+          "idModel": {
+            "type": "string",
+            "example": "586e8f681d4fe9b06a928307"
+          },
+          "modelType": {
+            "type": "string",
+            "enum": ["card", "board", "member"],
+            "example": "board"
+          },
+          "fieldGroup": {
+            "type": "string",
+            "example": "f6177ba6839d6fff0f73922c1cea105e793fda8a1433d466104dacc0b7c56955"
+          },
+          "display": {
+            "type": "object",
+            "properties": {
+              "cardFront": { "type": "boolean", "example": true },
+              "name": { "type": "string", "example": "Priority 🏔" },
+              "pos": { "type": "string", "example": "98304," },
+              "options": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/components/schemas/TrelloID",
+                      "example": "5ab10be237846c43015f1091"
+                    },
+                    "idCustomField": {
+                      "$ref": "#/components/schemas/TrelloID",
+                      "example": "5ab10be237846c43015f108e"
+                    },
+                    "value": {
+                      "type": "object",
+                      "properties": {
+                        "text": { "type": "string", "example": "High" }
+                      }
+                    },
+                    "color": { "type": "string", "example": "red" },
+                    "pos": { "type": "number", "example": 16384 }
+                  }
+                }
+              }
+            }
+          },
+          "type": { "type": "string", "example": "list" }
+        }
+      },
+      "CustomFieldItems": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "value": {
+            "type": "object",
+            "properties": { "checked": { "type": "string", "example": "true" } }
+          },
+          "idCustomField": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5b080fd8017bd1653b5480fa"
+          },
+          "idModel": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5b080ff194611b41aaaa9570"
+          },
+          "modelType": {
+            "type": "string",
+            "enum": ["card", "board", "member"],
+            "example": "card"
+          }
+        }
+      },
+      "CustomSticker": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "url": { "type": "string", "format": "url" },
+          "scaled": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "$ref": "#/components/schemas/TrelloID" }
+              }
+            }
+          }
+        }
+      },
+      "Emoji": {
+        "type": "object",
+        "properties": {
+          "trello": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "unified": { "type": "string", "example": "1F600" },
+                "name": { "type": "string", "example": "GRINNING FACE" },
+                "native": { "type": "string", "example": "😀" },
+                "shortName": { "type": "string", "example": "grinning" },
+                "shortNames": {
+                  "type": "array",
+                  "items": { "type": "string", "example": "grinning\"" }
+                },
+                "text": { "type": "string", "example": ":)" },
+                "texts": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": null
+                },
+                "category": { "type": "string", "example": "Smileys & People" },
+                "sheetX": { "type": "number", "example": 30 },
+                "sheetY": { "type": "number", "example": 24 },
+                "tts": { "type": "string", "example": "grinning face" },
+                "keywords": {
+                  "type": "array",
+                  "items": { "type": "string", "example": "face" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Enterprise": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "59c15d19566e197b23665901"
+          },
+          "name": { "type": "string", "example": "bentley_test" },
+          "displayName": {
+            "type": "string",
+            "example": "Bentley's Test Enterprise!"
+          },
+          "logoHash": { "type": "string", "nullable": true, "example": null },
+          "logoUrl": { "type": "string", "nullable": true, "example": null },
+          "prefs": {
+            "type": "object",
+            "properties": {
+              "ssoOnly": { "type": "boolean", "example": false },
+              "signup": {
+                "type": "object",
+                "properties": {
+                  "banner": { "type": "string" },
+                  "bannerHtml": {
+                    "type": "string",
+                    "example": "<p>Hello</p>\n"
+                  }
+                }
+              },
+              "mandatoryTransferDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true,
+                "example": null
+              },
+              "brandingColor": { "type": "string" },
+              "autoJoinOrganizations": { "type": "boolean", "example": false },
+              "notifications": { "type": "object" },
+              "maxMembers": {
+                "type": "number",
+                "nullable": true,
+                "example": null
+              }
+            }
+          },
+          "organizationPrefs": {
+            "type": "object",
+            "properties": {
+              "boardVisibilityRestrict": { "type": "object" },
+              "boardDeleteRestrict": { "type": "object" },
+              "attachmentRestrictions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "computer",
+                    "trello",
+                    "google-drive",
+                    "box",
+                    "onedrive",
+                    "link"
+                  ]
+                }
+              }
+            }
+          },
+          "ssoActivationFailed": { "type": "boolean" },
+          "idAdmins": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "enterpriseDomains": {
+            "type": "array",
+            "items": { "type": "string", "format": "url" }
+          },
+          "isRealEnterprise": { "type": "boolean", "example": true },
+          "pluginWhitelistingEnabled": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "idOrganizations": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "products": {
+            "type": "array",
+            "items": { "type": "number", "format": "integer" }
+          },
+          "licenses": {
+            "type": "object",
+            "properties": {
+              "maxMembers": {
+                "type": "number",
+                "nullable": true,
+                "format": "integer",
+                "example": null
+              },
+              "totalMembers": {
+                "type": "number",
+                "format": "integer",
+                "example": 5
+              },
+              "relatedEnterprises": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string", "example": "enterprise_name" },
+                    "displayName": {
+                      "type": "string",
+                      "example": "My Test Enterprise!"
+                    },
+                    "count": {
+                      "type": "number",
+                      "example": 5,
+                      "format": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "domains": {
+            "type": "array",
+            "items": { "type": "string", "format": "url" }
+          },
+          "dateOrganizationPrefsLastUpdated": {
+            "type": "string",
+            "example": "2019-08-22T18:15:53.546Z",
+            "format": "date"
+          },
+          "idp": {
+            "type": "object",
+            "properties": {
+              "requestSigned": { "type": "boolean", "example": false },
+              "certificate": {
+                "type": "string",
+                "nullable": true,
+                "example": null
+              },
+              "loginUrl": {
+                "type": "string",
+                "format": "url",
+                "nullable": true,
+                "example": null
+              }
+            }
+          }
+        }
+      },
+      "EnterpriseAdmin": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5dced8665015383ed5ca248c"
+          },
+          "fullName": { "type": "string", "example": "Bob Loblaw" },
+          "username": { "type": "string", "example": "bobloblaw" }
+        }
+      },
+      "EnterpriseAuditLog": {
+        "type": "object",
+        "properties": {
+          "idAction": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5dced8665015383ed5ca248c"
+          },
+          "type": {
+            "type": "string",
+            "example": "addOrganizationToEnterprise"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "example": "2018-04-26T17:03:25.155Z"
+          },
+          "memberCreator": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "5bc79d4206526d2279c1e6ea"
+              },
+              "username": { "type": "string", "example": "bobloblaw" },
+              "fullName": { "type": "string", "example": "Bob Loblaw (Trello)" }
+            }
+          },
+          "organization": {
+            "type": "object",
+            "properties": {
+              "enterpriseJoinRequest": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "idEnterprise": {
+                    "$ref": "#/components/schemas/TrelloID",
+                    "example": "617ac9070293e6612650e0ca"
+                  },
+                  "idMember": {
+                    "$ref": "#/components/schemas/TrelloID",
+                    "example": "5bc79d4206526d2279c1e6ea"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date",
+                    "example": "2018-04-26T17:03:25.155Z"
+                  }
+                }
+              },
+              "id": {
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "617ac9070293e6612650e0ca"
+              },
+              "name": { "type": "string", "example": "organization name" }
+            }
+          },
+          "member": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "5bc79d4206526d2279c1e6ea"
+              },
+              "username": { "type": "string", "example": "bentleycook" },
+              "fullName": { "type": "string", "example": "Bentley Cook" }
+            }
+          }
+        }
+      },
+      "Export": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5dced8665015383ed5ca248c"
+          },
+          "status": {
+            "type": "object",
+            "properties": {
+              "attempts": { "type": "number", "example": 0 },
+              "finished": { "type": "boolean", "example": false },
+              "stage": { "type": "string", "example": "Export_queued" }
+            }
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2019-11-15T16:55:02.000Z"
+          },
+          "size": { "type": "string", "nullable": true, "example": null },
+          "exportUrl": { "type": "string", "nullable": true, "example": null }
+        }
+      },
+      "TrelloID": {
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{24}$",
+        "example": "5abbe4b7ddc1b351ef961414"
+      },
+      "ViewFilter": {
+        "type": "string",
+        "enum": ["all", "closed", "none", "open"]
+      },
+      "Color": {
+        "type": "string",
+        "enum": [
+          "yellow",
+          "purple",
+          "blue",
+          "red",
+          "green",
+          "orange",
+          "black",
+          "sky",
+          "pink",
+          "lime"
+        ],
+        "nullable": true
+      },
+      "CardAging": { "type": "string", "enum": ["pirate", "regular"] },
+      "ImageDescriptor": {
+        "type": "object",
+        "properties": {
+          "width": {
+            "description": "The width of the image.",
+            "type": "integer",
+            "example": 100
+          },
+          "height": {
+            "description": "The height of the image.",
+            "type": "integer",
+            "example": 64
+          },
+          "url": {
+            "description": "The URL of the image.",
+            "format": "url",
+            "type": "string",
+            "example": "https://trello-backgrounds.s3.amazonaws.com/SharedBackground/100x64/abc/photo-123.jpg"
+          }
+        }
+      },
+      "Label": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the label.",
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID"
+          },
+          "idBoard": {
+            "type": "string",
+            "description": "The ID of the board the label is on.",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5abbe4b7ddc1b351ef961414"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name displayed for the label.",
+            "example": "Overdue",
+            "nullable": true,
+            "minLength": 0,
+            "maxLength": 16384
+          },
+          "color": {
+            "type": "string",
+            "$ref": "#/components/schemas/Color",
+            "description": "The color of the label. Null means no color and the label will not be shown on the front of Cards."
+          }
+        }
+      },
+      "ListFields": { "type": "string", "enum": ["id"] },
+      "TrelloList": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "name": {
+            "type": "string",
+            "description": "The name of the list",
+            "example": "Things to buy today"
+          },
+          "closed": { "type": "boolean" },
+          "pos": { "type": "number" },
+          "softLimit": { "type": "string" },
+          "idBoard": { "type": "string" },
+          "subscribed": { "type": "boolean" },
+          "limits": { "$ref": "#/components/schemas/Limits" }
+        }
+      },
+      "LimitsObject": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "enum": ["ok", "warning"] },
+          "disableAt": { "type": "number", "example": 36000 },
+          "warnAt": { "type": "number", "example": 32400 }
+        }
+      },
+      "Limits": {
+        "type": "object",
+        "properties": {
+          "attachments": {
+            "type": "object",
+            "properties": {
+              "perBoard": {
+                "type": "object",
+                "$ref": "#/components/schemas/LimitsObject"
+              }
+            }
+          }
+        }
+      },
+      "MemberFields": { "type": "string", "enum": ["id"] },
+      "Member": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/components/schemas/TrelloID" },
+          "activityBlocked": { "type": "boolean", "example": false },
+          "avatarHash": {
+            "type": "string",
+            "example": "fc8faaaee46666a4eb8b626c08933e16"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello-avatars.s3.amazonaws.com/fc8faaaee46666a4eb8b626c08933e16"
+          },
+          "bio": {
+            "type": "string",
+            "example": "👋 I'm a developer advocate at Trello!"
+          },
+          "bioData": {
+            "type": "object",
+            "properties": { "emoji": { "type": "object" } }
+          },
+          "confirmed": { "type": "boolean", "example": true },
+          "fullName": { "type": "string", "example": "Bentley Cook" },
+          "idEnterprise": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID"
+          },
+          "idEnterprisesDeactivated": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "idMemberReferrer": {
+            "$ref": "#/components/schemas/TrelloID",
+            "nullable": true,
+            "example": null
+          },
+          "idPremOrgsAdmin": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "initials": { "type": "string", "example": "BC" },
+          "memberType": {
+            "type": "string",
+            "enum": ["normal", "ghost"],
+            "example": "normal"
+          },
+          "nonPublic": {
+            "type": "object",
+            "description": "Profile data with restricted visibility. These fields are visible only to members of the\nsame organization. The values here (full name, for example) may differ from the values\nat the top level of the response.\n",
+            "properties": {
+              "fullName": { "type": "string", "example": "Bentley Cook" },
+              "initials": { "type": "string", "example": "BC" },
+              "avatarUrl": {
+                "type": "string",
+                "format": "url",
+                "example": "https://trello-members.s3.amazonaws.com/5b02e7f4e1facdc393169f9d/db2adf80c2e6c26b76e1f10400eb4c45",
+                "description": "A URL that references the non-public avatar for the member"
+              },
+              "avatarHash": {
+                "type": "string",
+                "example": "db2adf80c2e6c26b76e1f10400eb4c45"
+              }
+            }
+          },
+          "nonPublicAvailable": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether the response contains non-public profile data for the member"
+          },
+          "products": { "type": "array", "items": { "type": "integer" } },
+          "url": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello.com/bentleycook"
+          },
+          "username": { "type": "string", "example": "bentleycook" },
+          "status": {
+            "type": "string",
+            "enum": ["disconnected"],
+            "example": "disconnected"
+          },
+          "aaEmail": {
+            "type": "string",
+            "format": "email",
+            "nullable": true,
+            "example": null
+          },
+          "aaEnrolledDate": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "aaId": { "type": "string", "example": null, "nullable": true },
+          "avatarSource": {
+            "type": "string",
+            "enum": ["gravatar", "upload"],
+            "example": "gravatar"
+          },
+          "email": { "type": "string", "example": "bcook@atlassian.com" },
+          "gravatarHash": {
+            "type": "string",
+            "example": "0a1e804f6e35a65ae5e1f7ef4c92471c"
+          },
+          "idBoards": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "idOrganizations": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "idEnterprisesAdmin": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          "limits": { "$ref": "#/components/schemas/LimitsObject" },
+          "loginTypes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["password", "saml"],
+              "example": "password"
+            }
+          },
+          "marketingOptIn": {
+            "type": "object",
+            "properties": {
+              "optedIn": { "type": "boolean", "example": false },
+              "date": {
+                "type": "string",
+                "format": "date",
+                "example": "2018-04-26T17:03:25.155Z"
+              }
+            }
+          },
+          "messagesDismissed": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string", "example": "ad-security-features" },
+              "count": { "type": "string", "example": 4 },
+              "lastDismissed": {
+                "type": "string",
+                "format": "date",
+                "example": "2019-03-11T20:19:46.809Z"
+              },
+              "_id": {
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "5995d44573d197eada632a32"
+              }
+            }
+          },
+          "oneTimeMessagesDismissed": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "prefs": { "$ref": "#/components/schemas/MemberPrefs" },
+          "trophies": { "type": "array", "items": { "type": "string" } },
+          "uploadedAvatarHash": {
+            "type": "string",
+            "example": "dac3ad49ff117829dd63a79bb2ea3426"
+          },
+          "uploadedAvatarUrl": {
+            "type": "string",
+            "format": "url",
+            "example": "https://trello-avatars.s3.amazonaws.com/dac3ad49ff117829dd63a79bb2ea3426"
+          },
+          "premiumFeatures": { "type": "array", "items": { "type": "string" } },
+          "isAaMastered": { "type": "boolean", "example": false },
+          "ixUpdate": { "type": "number", "example": "48427" },
+          "idBoardsPinned": {
+            "type": "array",
+            "nullable": true,
+            "items": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        }
+      },
+      "MemberPrefs": {
+        "type": "object",
+        "properties": {
+          "timezoneInfo": {
+            "type": "object",
+            "properties": {
+              "offsetCurrent": { "type": "integer", "example": 360 },
+              "timezoneCurrent": { "type": "string", "example": "CST" },
+              "offsetNext": { "type": "integer", "example": 300 },
+              "dateNext": {
+                "type": "string",
+                "format": "date",
+                "example": "2020-03-08T08:00:00.000Z"
+              },
+              "timezoneNext": { "type": "string", "example": "CDT" }
+            }
+          },
+          "privacy": {
+            "type": "object",
+            "properties": {
+              "fullName": {
+                "type": "string",
+                "enum": ["public", "private", "collaborator"],
+                "example": "public"
+              },
+              "avatar": {
+                "type": "string",
+                "enum": ["public", "private", "collaborator"],
+                "example": "public"
+              }
+            }
+          },
+          "sendSummaries": { "type": "boolean", "example": true },
+          "minutesBetweenSummaries": { "type": "integer", "example": 60 },
+          "minutesBeforeDeadlineToNotify": {
+            "type": "integer",
+            "example": 1440
+          },
+          "colorBlind": { "type": "boolean", "example": true },
+          "locale": { "type": "string", "example": "en-AU" },
+          "timezone": { "type": "string", "example": "America/Chicago" },
+          "twoFactor": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "example": true },
+              "needsNewBackups": { "type": "boolean", "example": false }
+            }
+          }
+        }
+      },
+      "Memberships": {
+        "type": "object",
+        "description": "",
+        "properties": { "id": { "$ref": "#/components/schemas/TrelloID" } }
+      },
+      "NotificationFields": {
+        "type": "string",
+        "enum": [
+          "id",
+          "unread",
+          "type",
+          "date",
+          "dateRead",
+          "data",
+          "card",
+          "board",
+          "idMemberCreator",
+          "idAction",
+          "reactions"
+        ]
+      },
+      "Notification": {
+        "properties": {
+          "id": { "type": "string", "example": "5dc591ac425f2a223aba0a8e" },
+          "unread": { "type": "boolean", "example": true },
+          "type": {
+            "type": "string",
+            "enum": ["cardDueSoon"],
+            "example": "cardDueSoon"
+          },
+          "date": { "type": "string", "example": "2019-11-08T16:02:52.763Z" },
+          "dateRead": { "type": "string", "example": null },
+          "data": { "type": "string", "example": null },
+          "card": { "type": "object", "$ref": "#/components/schemas/Card" },
+          "board": { "type": "object", "$ref": "#/components/schemas/Board" },
+          "idMemberCreator": {
+            "$ref": "#/components/schemas/TrelloID",
+            "nullable": true,
+            "example": null
+          },
+          "idAction": {
+            "$ref": "#/components/schemas/TrelloID",
+            "nullable": true,
+            "example": null
+          },
+          "reactions": { "type": "array", "example": [] }
+        }
+      },
+      "NotificationChannelSettings": {
+        "properties": {
+          "id": { "type": "string", "example": "5dc591ac425f2a223aba0a8e" },
+          "idMember": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5589c3ea49b40cedc28cf70e"
+          },
+          "blockedKeys": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/BlockedKey" }
+          },
+          "channel": { "$ref": "#/components/schemas/Channel" }
+        }
+      },
+      "OrganizationFields": { "type": "string", "enum": ["id", "name"] },
+      "Organization": {
+        "type": "object",
+        "properties": { "id": { "$ref": "#/components/schemas/TrelloID" } }
+      },
+      "PendingOrganizations": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "617ac9070293e6612650e0ca"
+          },
+          "idMember": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5589c3ea49b40cedc28cf70e"
+          },
+          "memberRequestor": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "$ref": "#/components/schemas/TrelloID",
+                "example": "59cd149051aa57a706962996"
+              },
+              "fullName": { "type": "string", "example": "Bob Loblaw (Trello)" }
+            }
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "example": "2018-10-17T19:10:14.808Z"
+          },
+          "displayName": { "type": "string", "example": "Organization Name" },
+          "membershipCount": { "type": "number", "example": 2 },
+          "logoUrl": { "type": "string", "nullable": true, "example": null },
+          "transferability": {
+            "type": "object",
+            "properties": {
+              "transferrable": { "type": "boolean", "example": true },
+              "newBillableMembers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/components/schemas/TrelloID",
+                      "example": "5ab10be237846c43015f1091"
+                    },
+                    "fullName": { "type": "string", "example": "Bob Loblaw" },
+                    "username": { "type": "string", "example": "bobloblaw" },
+                    "initials": { "type": "string", "example": "BL" },
+                    "avatarHash": {
+                      "type": "string",
+                      "example": "fc8faaaee46666a4eb8b626c08933e16"
+                    }
+                  }
+                }
+              },
+              "restrictedMembers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/components/schemas/TrelloID",
+                      "example": "5ab10be237846c43015f1091"
+                    },
+                    "fullName": { "type": "string", "example": "Bob Loblaw" },
+                    "username": { "type": "string", "example": "bobloblaw" },
+                    "initials": { "type": "string", "example": "BL" },
+                    "avatarHash": {
+                      "type": "string",
+                      "example": "fc8faaaee46666a4eb8b626c08933e16"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Plugin": {
+        "type": "object",
+        "properties": { "id": { "$ref": "#/components/schemas/TrelloID" } }
+      },
+      "PluginData": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5c487f39294cab6ac1d6b305"
+          },
+          "idPlugin": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "55a5d915446f517774210003"
+          },
+          "scope": {
+            "type": "string",
+            "enum": ["member", "board", "organization", "card"],
+            "example": "organization"
+          },
+          "idModel": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "586e8d7b1af892b26d5b76b1"
+          },
+          "value": {
+            "type": "string",
+            "example": "{\"token\":\"S=s458:U=bda7cda:E=16fd2e21f55:C=1687b30f2c0:P=185:A=it-team-0604:V=2:H=3b0f3bac9c2a2af766202ebb9530a4a5\"}"
+          },
+          "access": {
+            "type": "string",
+            "enum": ["private", "shared"],
+            "example": "private"
+          }
+        }
+      },
+      "PluginListing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5a7cd2f8f99c517f58da1579"
+          },
+          "name": { "type": "string", "example": "Attachment Section Example" },
+          "locale": { "type": "string", "example": "en-US" },
+          "description": {
+            "type": "string",
+            "example": "The [Glitch](https://glitch.com) Power-Up allows you to..."
+          },
+          "overview": { "type": "string", "example": "" }
+        }
+      },
+      "Prefs": {
+        "type": "object",
+        "properties": {
+          "permissionLevel": { "type": "string", "enum": ["org", "board"] },
+          "hideVotes": { "type": "boolean" },
+          "voting": { "type": "string", "enum": ["disabled", "enabled"] },
+          "comments": { "type": "string" },
+          "invitations": { "enum": ["admins", "members"] },
+          "selfJoin": { "type": "boolean" },
+          "cardCovers": { "type": "boolean" },
+          "isTemplate": { "type": "boolean" },
+          "cardAging": { "$ref": "#/components/schemas/CardAging" },
+          "calendarFeedEnabled": { "type": "boolean" },
+          "background": { "$ref": "#/components/schemas/TrelloID" },
+          "backgroundImage": { "type": "string", "format": "uri" },
+          "backgroundImageScaled": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ImageDescriptor" }
+          },
+          "backgroundTile": { "type": "boolean" },
+          "backgroundBrightness": { "type": "string", "example": "dark" },
+          "backgroundBottomColor": { "type": "string", "example": "#1e2e00" },
+          "backgroundTopColor": { "type": "string", "example": "#ffffff" },
+          "canBePublic": { "type": "boolean" },
+          "canBeEnterprise": { "type": "boolean" },
+          "canBeOrg": { "type": "boolean" },
+          "canBePrivate": { "type": "boolean" },
+          "canInvite": { "type": "boolean" }
+        }
+      },
+      "SavedSearch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5589b47349b40cedc28ceae2"
+          },
+          "name": { "type": "string", "example": "My Cards" },
+          "query": { "type": "string", "example": "@me" },
+          "pos": {
+            "$ref": "#/components/schemas/posStringOrNumber",
+            "example": 1638
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "58dd6dcaf8b86744d3cb4cde"
+          },
+          "name": { "type": "string", "example": "My Collection" }
+        }
+      },
+      "TokenPermission": {
+        "type": "object",
+        "properties": {
+          "idModel": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TrelloID" },
+              { "type": "string", "enum": ["*"] }
+            ]
+          },
+          "modelType": {
+            "type": "string",
+            "enum": ["board", "member", "organization", "enterprise"]
+          },
+          "read": { "type": "boolean" },
+          "write": { "type": "boolean" }
+        }
+      },
+      "TokenFields": {
+        "type": "string",
+        "enum": [
+          "identifier",
+          "idMember",
+          "dateCreated",
+          "dateExpires",
+          "permissions"
+        ]
+      },
+      "Token": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5da728c55235b443c5b97181"
+          },
+          "identifier": { "type": "string", "example": "App Name" },
+          "idMember": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "5589c3ea49b40cedc28cf70e"
+          },
+          "dateCreated": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2019-10-16T14:27:17.304Z"
+          },
+          "dateExpires": {
+            "type": "string",
+            "format": "date-time",
+            "example": null,
+            "nullable": true
+          },
+          "permissions": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TokenPermission" }
+          }
+        }
+      },
+      "TransferrableOrganization": {
+        "type": "object",
+        "properties": {
+          "transferrable": { "type": "boolean", "example": true },
+          "newBillableMembers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/TrelloID",
+                  "example": "5ab10be237846c43015f1091"
+                },
+                "fullName": { "type": "string", "example": "Bob Loblaw" },
+                "username": { "type": "string", "example": "bobloblaw" },
+                "initials": { "type": "string", "example": "BL" },
+                "avatarHash": {
+                  "type": "string",
+                  "example": "fc8faaaee46666a4eb8b626c08933e16"
+                }
+              }
+            }
+          },
+          "restrictedMembers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/TrelloID",
+                  "example": "5ab10be237846c43015f1091"
+                },
+                "fullName": { "type": "string", "example": "Bob Loblaw" },
+                "username": { "type": "string", "example": "bobloblaw" },
+                "initials": { "type": "string", "example": "BL" },
+                "avatarHash": {
+                  "type": "string",
+                  "example": "fc8faaaee46666a4eb8b626c08933e16"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Webhook": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "58dd6dcaf8b86744d3cb4cde"
+          },
+          "description": { "type": "string", "example": "Board Webhook" },
+          "idModel": {
+            "$ref": "#/components/schemas/TrelloID",
+            "example": "59cd149051aa57a706962996"
+          },
+          "callbackURL": {
+            "type": "string",
+            "format": "url",
+            "example": "https://mywebhookurl.com/?type=board"
+          },
+          "active": { "type": "boolean", "example": true },
+          "consecutiveFailures": { "type": "number", "example": 0 },
+          "firstConsecutiveFailDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "example": null
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "required": ["code", "message"]
+      },
+      "CFValue": {
+        "type": "object",
+        "properties": { "number": { "type": "string" } }
+      },
+      "customFieldItemValue": {
+        "type": "object",
+        "properties": { "value": { "type": "object" } }
+      }
+    },
+    "responses": {
+      "NotFound": {
+        "description": "The specified resource was not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  },
+  "security": [{ "APIKey": [], "APIToken": [] }],
+  "paths": {
+    "/actions/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Action",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get an Action",
+        "description": "Get an Action",
+        "operationId": "get-actions-id",
+        "parameters": [
+          {
+            "name": "display",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "entities",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of action [fields](/cloud/trello/guides/rest-api/object-definitions/#action-object)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "member",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          },
+          {
+            "name": "memberCreator",
+            "in": "query",
+            "description": "Whether to include the member object for the creator of the action",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "memberCreator_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update an Action",
+        "description": "Update a specific Action. Only comment actions can be updated. Used to edit the content of a comment.",
+        "operationId": "put-actions-id",
+        "parameters": [
+          {
+            "name": "text",
+            "in": "query",
+            "description": "The new text for the comment",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete an Action",
+        "description": "Delete a specific action. Only comment actions can be deleted.",
+        "operationId": "delete-actions-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/actions/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a specific field on an Action",
+        "description": "Get a specific property of an action",
+        "operationId": "get-actions-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "An action field",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/ActionFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Action" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/board": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Board for an Action",
+        "description": "Get the Board for an Action",
+        "operationId": "get-actions-id-board",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board fields",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/BoardFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Board" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/card": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Card for an Action",
+        "description": "Get the card for an action",
+        "operationId": "get-actions-id-card",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of card fields",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CardFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Card" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/list": {
+      "get": {
+        "tags": [],
+        "summary": "Get the List for an Action",
+        "description": "Get the List for an Action",
+        "operationId": "get-actions-id-list",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of list fields",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ListFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrelloList" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/member": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Member of an Action",
+        "description": "Gets the member of an action (not the creator)",
+        "operationId": "get-actions-id-member",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member fields",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/memberCreator": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Member Creator of an Action",
+        "description": "Get the Member who created the Action",
+        "operationId": "get-actions-id-membercreator",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member fields",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/organization": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Organization of an Action",
+        "description": "Get the Organization of an Action",
+        "operationId": "get-actions-id-organization",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization fields",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/actions/{id}/text": {
+      "put": {
+        "tags": [],
+        "summary": "Update a Comment Action",
+        "description": "Update a comment action",
+        "operationId": "put-actions-id-text",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the action to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The new text for the comment",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/actions/{idAction}/reactions": {
+      "parameters": [
+        {
+          "name": "idAction",
+          "in": "path",
+          "description": "The ID of the action",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Action's Reactions",
+        "description": "List reactions for an action",
+        "operationId": "get-actions-idaction-reactions",
+        "parameters": [
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Whether to load the member as a nested resource. See [Members Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "emoji",
+            "in": "query",
+            "description": "Whether to load the emoji as a nested resource.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Reaction for Action",
+        "description": "Adds a new reaction to an action",
+        "operationId": "post-actions-idaction-reactions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shortName": {
+                    "type": "string",
+                    "description": "The primary `shortName` of the emoji to add. See [/emoji](#emoji)"
+                  },
+                  "skinVariation": {
+                    "type": "string",
+                    "description": "The `skinVariation` of the emoji to add. See [/emoji](#emoji)"
+                  },
+                  "native": {
+                    "type": "string",
+                    "description": "The emoji to add as a native unicode emoji. See [/emoji](#emoji)"
+                  },
+                  "unified": {
+                    "type": "string",
+                    "description": "The `unified` value of the emoji to add. See [/emoji](#emoji)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/actions/{idAction}/reactions/{id}": {
+      "parameters": [
+        {
+          "name": "idAction",
+          "in": "path",
+          "description": "The ID of the Action",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the reaction",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Action's Reaction",
+        "description": "Get information for a reaction",
+        "operationId": "get-actions-idaction-reactions-id",
+        "parameters": [
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Whether to load the member as a nested resource. See [Members Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#members-nested-resource)",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "emoji",
+            "in": "query",
+            "description": "Whether to load the emoji as a nested resource.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete Action's Reaction",
+        "description": "Deletes a reaction",
+        "operationId": "delete-actions-idaction-reactions-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/actions/{idAction}/reactionsSummary": {
+      "get": {
+        "tags": [],
+        "summary": "List Action's summary of Reactions",
+        "description": "List a summary of all reactions for an action",
+        "operationId": "get-actions-idaction-reactionsummary",
+        "parameters": [
+          {
+            "name": "idAction",
+            "in": "path",
+            "description": "The ID of the action",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/applications/{key}/compliance": {
+      "parameters": [
+        {
+          "name": "key",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Application's compliance data",
+        "description": "",
+        "operationId": "applications-key-compliance",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/batch": {
+      "get": {
+        "tags": [],
+        "summary": "Batch Requests",
+        "description": "Make up to 10 GET requests in a single, batched API call.",
+        "operationId": "get-batch",
+        "parameters": [
+          {
+            "name": "urls",
+            "in": "query",
+            "description": "A list of API routes. Maximum of 10 routes allowed. The routes should begin with a forward slash and should not include the API version number - e.g. \"urls=/members/trello,/cards/[cardId]\"",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/memberships": {
+      "get": {
+        "tags": [],
+        "summary": "Get Memberships of a Board",
+        "description": "Get information about the memberships users have to the board.",
+        "operationId": "get-boards-id-memberships",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of `admins`, `all`, `none`, `normal`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["admins", "all", "none", "normal"]
+            }
+          },
+          {
+            "name": "activity",
+            "in": "query",
+            "description": "Works for premium organizations only.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "orgMemberType",
+            "in": "query",
+            "description": "Shows the type of member to the org the user is. For instance, an org admin will have a `orgMemberType` of `admin`.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Determines whether to include a [nested member object](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "Fields to show if `member=true`. Valid values: [nested member resource fields](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "fullname,username"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Memberships" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/boards/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Board",
+        "description": "Request a single board.",
+        "operationId": "get-boards-id",
+        "parameters": [
+          {
+            "name": "actions",
+            "in": "query",
+            "description": "This is a nested resource. Read more about actions as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "boardStars",
+            "in": "query",
+            "description": "Valid values are one of: `mine` or `none`.",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "cards",
+            "in": "query",
+            "description": "This is a nested resource. Read more about cards as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "card_pluginData",
+            "in": "query",
+            "description": "Use with the `cards` param to include card pluginData with the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "checklists",
+            "in": "query",
+            "description": "This is a nested resource. Read more about checklists as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "customFields",
+            "in": "query",
+            "description": "This is a nested resource. Read more about custom fields as nested resources [here](#custom-fields-nested-resource).",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "The fields of the board to be included in the response. Valid values: all or a comma-separated list of: closed, dateLastActivity, dateLastView, desc, descData, idMemberCreator, idOrganization, invitations, invited, labelNames, memberships, name, pinned, powerUps, prefs, shortLink, shortUrl, starred, subscribed, url",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "name,desc,descData,closed,idOrganization,pinned,url,shortUrl,prefs,labelNames"
+            }
+          },
+          {
+            "name": "labels",
+            "in": "query",
+            "description": "This is a nested resource. Read more about labels as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lists",
+            "in": "query",
+            "description": "This is a nested resource. Read more about lists as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "open" }
+          },
+          {
+            "name": "members",
+            "in": "query",
+            "description": "This is a nested resource. Read more about members as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "memberships",
+            "in": "query",
+            "description": "This is a nested resource. Read more about memberships as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "pluginData",
+            "in": "query",
+            "description": "Determines whether the pluginData for this board should be returned. Valid values: true or false.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organization",
+            "in": "query",
+            "description": "This is a nested resource. Read more about organizations as nested resources [here](/cloud/trello/guides/rest-api/nested-resources/).",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organization_pluginData",
+            "in": "query",
+            "description": "Use with the `organization` param to include organization pluginData with the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "myPrefs",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Also known as collections, tags, refer to the collection(s) that a Board belongs to.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Board" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Board",
+        "description": "Update an existing board by id",
+        "operationId": "put-boards-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the board. 1 to 16384 characters long.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "A new description for the board, 0 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "closed",
+            "in": "query",
+            "description": "Whether the board is closed",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "subscribed",
+            "in": "query",
+            "description": "Whether the acting user is subscribed to the board",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganization",
+            "in": "query",
+            "description": "The id of the Workspace the board should be moved to",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/permissionLevel",
+            "in": "query",
+            "description": "One of: org, private, public",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/selfJoin",
+            "in": "query",
+            "description": "Whether Workspace members can join the board themselves",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "prefs/cardCovers",
+            "in": "query",
+            "description": "Whether card covers should be displayed on this board",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "prefs/hideVotes",
+            "in": "query",
+            "description": "Determines whether the Voting Power-Up should hide who voted on cards or not.",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "prefs/invitations",
+            "in": "query",
+            "description": "Who can invite people to this board. One of: admins, members",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/voting",
+            "in": "query",
+            "description": "Who can vote on this board. One of disabled, members, observers, org, public",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/comments",
+            "in": "query",
+            "description": "Who can comment on cards on this board. One of: disabled, members, observers, org, public",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/background",
+            "in": "query",
+            "description": "The id of a custom background or one of: blue, orange, green, red, purple, pink, lime, sky, grey",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/cardAging",
+            "in": "query",
+            "description": "One of: pirate, regular",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/calendarFeedEnabled",
+            "in": "query",
+            "description": "Determines whether the calendar feed is enabled or not.",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "labelNames/green",
+            "in": "query",
+            "description": "Name for the green label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "labelNames/yellow",
+            "in": "query",
+            "description": "Name for the yellow label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "labelNames/orange",
+            "in": "query",
+            "description": "Name for the orange label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "labelNames/red",
+            "in": "query",
+            "description": "Name for the red label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "labelNames/purple",
+            "in": "query",
+            "description": "Name for the purple label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "labelNames/blue",
+            "in": "query",
+            "description": "Name for the blue label. 1 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Board",
+        "description": "Delete a board.",
+        "operationId": "delete-boards-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to delete",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a field on a Board",
+        "description": "Get a single, specific field on a board",
+        "operationId": "get-boards-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "The field you'd like to receive. Valid values: closed, dateLastActivity, dateLastView, desc, descData, idMemberCreator, idOrganization, invitations, invited, labelNames, memberships, name, pinned, powerUps, prefs, shortLink, shortUrl, starred, subscribed, url.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{boardId}/actions": {
+      "get": {
+        "tags": [],
+        "summary": "Get Actions of a Board",
+        "description": "",
+        "operationId": "get-boards-id-actions",
+        "parameters": [
+          {
+            "name": "boardId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "A comma-separated list of [action types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/cards/{idCard}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Card on a Board",
+        "description": "Get a single Card on a Board.",
+        "operationId": "get-boards-id-cards-idcard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idCard",
+            "in": "path",
+            "description": "The id the card to retrieve.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{boardId}/boardStars": {
+      "get": {
+        "tags": [],
+        "summary": "Get boardStars on a Board",
+        "description": "",
+        "operationId": "get-boards-id-boardstars",
+        "parameters": [
+          {
+            "name": "boardId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Valid values: mine, none",
+            "required": false,
+            "schema": { "type": "string", "default": "mine" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/BoardStars" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/boards/{id}/checklists": {
+      "get": {
+        "tags": [],
+        "summary": "Get Checklists on a Board",
+        "description": "Get all of the checklists on a Board.",
+        "operationId": "boards-id-checklists",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/cards": {
+      "get": {
+        "tags": [],
+        "summary": "Get Cards on a Board",
+        "description": "Get all of the open Cards on a Board.",
+        "operationId": "get-boards-id-cards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/cards/{filter}": {
+      "get": {
+        "tags": [],
+        "summary": "Get filtered Cards on a Board",
+        "description": "Get the Cards on a Board that match a given filter.",
+        "operationId": "get-boards-id-cards-filter",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Board",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter",
+            "in": "path",
+            "description": "Valid Values: all, closed, none, open, visible.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "closed", "none", "open", "visible"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/customFields": {
+      "get": {
+        "tags": [],
+        "summary": "Get Custom Fields for Board",
+        "description": "Get the Custom Field Definitions that exist on a board.",
+        "operationId": "get-boards-id-customfields",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CustomField" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/boards/{id}/labels": {
+      "get": {
+        "tags": [],
+        "summary": "Get Labels on a Board",
+        "description": "Get all of the Labels on a Board.",
+        "operationId": "get-boards-id-labels",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Board.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "The fields to be returned for the Labels.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/Label" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of Labels to be returned.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50,
+              "minimum": 0,
+              "maximum": 1000
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create a Label on a Board",
+        "description": "Create a new Label on a Board.",
+        "operationId": "post-boards-id-labels",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the label to be created. 1 to 16384 characters long.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "description": "Sets the color of the new label. Valid values are a label color or `null`.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/lists": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the board",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Lists on a Board",
+        "description": "Get the Lists on a Board",
+        "operationId": "get-boards-id-lists",
+        "parameters": [
+          {
+            "name": "cards",
+            "in": "query",
+            "description": "Filter to apply to Cards.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/ViewFilter" }
+          },
+          {
+            "name": "card_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/#card-object)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter to apply to Lists",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/ViewFilter" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/TrelloList" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create a List on a Board",
+        "description": "Create a new List on a Board.",
+        "operationId": "post-boards-id-lists",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the list to be created. 1 to 16384 characters long.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "Determines the position of the list. Valid values: `top`, `bottom`, or a positive number.",
+            "required": false,
+            "schema": { "type": "string", "default": "top" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TrelloList" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/boards/{id}/lists/{filter}": {
+      "get": {
+        "tags": [],
+        "summary": "Get filtered Lists on a Board",
+        "description": "",
+        "operationId": "get-boards-id-lists-filter",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "path",
+            "description": "One of `all`, `closed`, `none`, `open`",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/ViewFilter" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/members": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the board",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get the Members of a Board",
+        "description": "Get the Members for a board",
+        "operationId": "get-boards-id-members",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Invite Member to Board via email",
+        "description": "Invite a Member to a Board via their email address.",
+        "operationId": "put-boards-id-members",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "description": "The email address of a user to add as a member of the board.",
+            "required": true,
+            "schema": { "type": "string", "format": "email" }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Valid values: admin, normal, observer. Determines what type of member the user being added should be of the board.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "normal",
+              "enum": ["admin", "normal", "observer"]
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string",
+                    "description": "The full name of the user to as a member of the board. Must have a length of at least 1 and cannot begin nor end with a space."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/members/{idMember}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The id of the board to update",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idMember",
+          "in": "path",
+          "description": "The id of the member to add to the board.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "put": {
+        "tags": [],
+        "summary": "Add a Member to a Board",
+        "description": "Add a member to the board.",
+        "operationId": "put-boards-id-members-idmember",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "One of: admin, normal, observer. Determines the type of member this user will be on the board.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["admin", "normal", "observer"]
+            }
+          },
+          {
+            "name": "allowBillableGuest",
+            "in": "query",
+            "description": "Optional param that allows organization admins to add multi-board guests onto a board.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Remove Member from Board",
+        "description": "",
+        "operationId": "boardsidmembersidmember",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/memberships/{idMembership}": {
+      "put": {
+        "tags": [],
+        "summary": "Update Membership of Member on a Board",
+        "description": "Update an existing board by id",
+        "operationId": "put-boards-id-memberships-idmembership",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMembership",
+            "in": "path",
+            "description": "The id of a membership that should be added to this board.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "One of: admin, normal, observer. Determines the type of member that this membership will be to this board.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["admin", "normal", "observer"]
+            }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "Valid values: all, avatarHash, bio, bioData, confirmed, fullName, idPremOrgsAdmin, initials, memberType, products, status, url, username",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "default": "fullName, username",
+              "enum": [
+                "all",
+                "avatarHash",
+                "bio",
+                "bioData",
+                "confirmed",
+                "fullName",
+                "idPremOrgsAdmin",
+                "initials",
+                "memberType",
+                "products",
+                "status",
+                "url",
+                "username"
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/emailPosition": {
+      "put": {
+        "tags": [],
+        "summary": "Update emailPosition Pref on a Board",
+        "description": "Update emailPosition Pref on a Board",
+        "operationId": "put-boards-id-myprefs-emailposition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Valid values: bottom, top. Determines the position of the email address.",
+            "required": true,
+            "schema": { "type": "string", "enum": ["bottom", "top"] }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/idEmailList": {
+      "put": {
+        "tags": [],
+        "summary": "Update idEmailList Pref on a Board",
+        "description": "Change the default list that email-to-board cards are created in.",
+        "operationId": "put-boards-id-myprefs-idemaillist",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The id of an email list.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/showListGuide": {
+      "put": {
+        "tags": [],
+        "summary": "Update showListGuide Pref on a Board",
+        "operationId": "put-boards-id-myPrefs-showlistguide",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether to show the list guide.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/showSidebar": {
+      "put": {
+        "tags": [],
+        "summary": "Update showSidebar Pref on a Board",
+        "operationId": "put-boards-id-myPrefs-showsidebar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether to show the side bar.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/showSidebarActivity": {
+      "put": {
+        "tags": [],
+        "summary": "Update showSidebarActivity Pref on a Board",
+        "operationId": "put-boards-id-myPrefs-showsidebaractivity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether to show sidebar activity.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/showSidebarBoardActions": {
+      "put": {
+        "tags": [],
+        "summary": "Update showSidebarBoardActions Pref on a Board",
+        "operationId": "put-boards-id-myPrefs-showsidebarboardactions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether to show the sidebar board actions.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/myPrefs/showSidebarMembers": {
+      "put": {
+        "tags": [],
+        "summary": "Update showSidebarMembers Pref on a Board",
+        "operationId": "put-boards-id-myPrefs-showsidebarmembers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether to show members of the board in the sidebar.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Board",
+        "description": "Create a new board.",
+        "operationId": "post-boards",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the board. 1 to 16384 characters long.",
+            "required": true,
+            "schema": { "type": "string", "maxLength": 16384, "minLength": 1 }
+          },
+          {
+            "name": "defaultLabels",
+            "in": "query",
+            "description": "Determines whether to use the default set of labels.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "defaultLists",
+            "in": "query",
+            "description": "Determines whether to add the default set of lists to a board (To Do, Doing, Done). It is ignored if `idBoardSource` is provided.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "A new description for the board, 0 to 16384 characters long",
+            "required": false,
+            "schema": { "type": "string", "minLength": 0, "maxLength": 16384 }
+          },
+          {
+            "name": "idOrganization",
+            "in": "query",
+            "description": "The id or name of the Workspace the board should belong to.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idBoardSource",
+            "in": "query",
+            "description": "The id of a board to copy into the new board.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "keepFromSource",
+            "in": "query",
+            "description": "To keep cards from the original board pass in the value `cards`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "none",
+              "enum": ["cards", "none"]
+            }
+          },
+          {
+            "name": "powerUps",
+            "in": "query",
+            "description": "The Power-Ups that should be enabled on the new board. One of: `all`, `calendar`, `cardAging`, `recap`, `voting`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "calendar", "cardAging", "recap", "voting"]
+            }
+          },
+          {
+            "name": "prefs_permissionLevel",
+            "in": "query",
+            "description": "The permissions level of the board. One of: `org`, `private`, `public`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "private",
+              "enum": ["org", "private", "public"]
+            }
+          },
+          {
+            "name": "prefs_voting",
+            "in": "query",
+            "description": "Who can vote on this board. One of `disabled`, `members`, `observers`, `org`, `public`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "disabled",
+              "enum": ["disabled", "members", "observers", "org", "public"]
+            }
+          },
+          {
+            "name": "prefs_comments",
+            "in": "query",
+            "description": "Who can comment on cards on this board. One of: `disabled`, `members`, `observers`, `org`, `public`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "members",
+              "enum": ["disabled", "members", "observers", "org", "public"]
+            }
+          },
+          {
+            "name": "prefs_invitations",
+            "in": "query",
+            "description": "Determines what types of members can invite users to join. One of: `admins`, `members`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "members",
+              "enum": ["members", "admins"]
+            }
+          },
+          {
+            "name": "prefs_selfJoin",
+            "in": "query",
+            "description": "Determines whether users can join the boards themselves or whether they have to be invited.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "prefs_cardCovers",
+            "in": "query",
+            "description": "Determines whether card covers are enabled.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "prefs_background",
+            "in": "query",
+            "description": "The id of a custom background or one of: `blue`, `orange`, `green`, `red`, `purple`, `pink`, `lime`, `sky`, `grey`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "blue",
+              "enum": [
+                "blue",
+                "orange",
+                "green",
+                "red",
+                "purple",
+                "pink",
+                "lime",
+                "sky",
+                "grey"
+              ]
+            }
+          },
+          {
+            "name": "prefs_cardAging",
+            "in": "query",
+            "description": "Determines the type of card aging that should take place on the board if card aging is enabled. One of: `pirate`, `regular`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "regular",
+              "enum": ["pirate", "regular"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/calendarKey/generate": {
+      "post": {
+        "tags": [],
+        "summary": "Create a calendarKey for a Board",
+        "description": "Create a new board.",
+        "operationId": "post-boards-id-calendarkey-generate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/emailKey/generate": {
+      "post": {
+        "tags": [],
+        "summary": "Create a emailKey for a Board",
+        "description": "",
+        "operationId": "post-boards-id-emailkey-generate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/idTags": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Tag for a Board",
+        "operationId": "post-boards-id-idtags",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The id of a tag from the organization to which this board belongs.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/markedAsViewed": {
+      "post": {
+        "tags": [],
+        "summary": "Mark Board as viewed",
+        "description": "",
+        "operationId": "post-boards-id-markedasviewed",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the board to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/boardPlugins": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Board",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Enabled Power-Ups on Board",
+        "description": "Get the enabled Power-Ups on a board",
+        "operationId": "get-boards-id-boardplugins",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Plugin" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Enable a Power-Up on a Board",
+        "description": "Enable a Power-Up on a Board",
+        "operationId": "post-boards-id-boardplugins",
+        "parameters": [
+          {
+            "name": "idPlugin",
+            "in": "query",
+            "description": "The ID of the Power-Up to enable",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": true,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/boardPlugins/{idPlugin}": {
+      "delete": {
+        "tags": [],
+        "summary": "Disable a Power-Up on a Board",
+        "description": "Disable a Power-Up on a board",
+        "operationId": "delete-boards-id-boardplugins",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idPlugin",
+            "in": "path",
+            "description": "The ID of the Power-Up to disable",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": true,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/boards/{id}/plugins": {
+      "get": {
+        "tags": [],
+        "summary": "Get Power-Ups on a Board",
+        "description": "List the Power-Ups on a board",
+        "operationId": "get-board-id-plugins",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the board",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of: `enabled` or `available`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "enabled",
+              "enum": ["enabled", "available"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Plugin" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards": {
+      "post": {
+        "tags": [],
+        "summary": "Create a new Card",
+        "description": "Create a new card",
+        "operationId": "post-cards",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name for the card",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "The description for the card",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the new card. `top`, `bottom`, or a positive float",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                { "type": "string", "enum": ["top", "bottom"] },
+                { "type": "number", "format": "float", "minimum": 0 }
+              ]
+            }
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "A due date for the card",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "The start date of a card, or `null`",
+            "required": false,
+            "schema": { "nullable": true, "type": "string", "format": "date" }
+          },
+          {
+            "name": "dueComplete",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "idList",
+            "in": "query",
+            "description": "The ID of the list the card should be created in",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMembers",
+            "in": "query",
+            "description": "Comma-separated list of member IDs to add to the card",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "oneOf": [{ "$ref": "#/components/schemas/TrelloID" }]
+              }
+            }
+          },
+          {
+            "name": "idLabels",
+            "in": "query",
+            "description": "Comma-separated list of label IDs to add to the card",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "oneOf": [{ "$ref": "#/components/schemas/TrelloID" }]
+              }
+            }
+          },
+          {
+            "name": "urlSource",
+            "in": "query",
+            "description": "A URL starting with `http://` or `https://`",
+            "required": false,
+            "schema": { "type": "string", "format": "url" }
+          },
+          {
+            "name": "fileSource",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string", "format": "binary" }
+          },
+          {
+            "name": "mimeType",
+            "in": "query",
+            "description": "The mimeType of the attachment. Max length 256",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idCardSource",
+            "in": "query",
+            "description": "The ID of a card to copy into the new card",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "keepFromSource",
+            "in": "query",
+            "description": "If using `idCardSource` you can specify which properties to copy over. `all` or comma-separated list of: `attachments,checklists,customFields,comments,due,start,labels,members,start,stickers`",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": [
+                "all",
+                "attachments",
+                "checklists",
+                "comments",
+                "customFields",
+                "due",
+                "start",
+                "labels",
+                "members",
+                "start",
+                "stickers"
+              ]
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "description": "For use with/by the Map View",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "locationName",
+            "in": "query",
+            "description": "For use with/by the Map View",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "coordinates",
+            "in": "query",
+            "description": "For use with/by the Map View. Should take the form latitude,longitude",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Card" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Card",
+        "description": "Get a card by its ID",
+        "operationId": "get-cards-id",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of [fields](/cloud/trello/guides/rest-api/object-definitions/). **Defaults**: `badges, checkItemStates, closed, dateLastActivity, desc, descData, due, start, email, idBoard, idChecklists, idLabels, idList, idMembers, idShort, idAttachmentCover, manualCoverAttachment, labels, name, pos, shortUrl, url`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "actions",
+            "in": "query",
+            "description": "See the [Actions Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "attachments",
+            "in": "query",
+            "description": "`true`, `false`, or `cover`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "oneOf": [
+                { "type": "string", "enum": ["cover"] },
+                { "type": "boolean" }
+              ],
+              "default": false
+            }
+          },
+          {
+            "name": "attachment_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of attachment [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "members",
+            "in": "query",
+            "description": "Whether to return member objects for members on the card",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/). **Defaults**: `avatarHash, fullName, initials, username`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "membersVoted",
+            "in": "query",
+            "description": "Whether to return member objects for members who voted on the card",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "memberVoted_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/). **Defaults**: `avatarHash, fullName, initials, username`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkItemStates",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "checklists",
+            "in": "query",
+            "description": "Whether to return the checklists on the card. `all` or `none`",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "checklist_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of `idBoard,idCard,name,pos`",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "description": "Whether to return the board object the card is on",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object). **Defaults**: `name, desc, descData, closed, idOrganization, pinned, url, prefs`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "list",
+            "in": "query",
+            "description": "See the [Lists Nested Resource](/cloud/trello/guides/rest-api/nested-resources/)",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "pluginData",
+            "in": "query",
+            "description": "Whether to include pluginData on the card with the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "stickers",
+            "in": "query",
+            "description": "Whether to include sticker models with the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "sticker_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "customFieldItems",
+            "in": "query",
+            "description": "Whether to include the customFieldItems",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Card" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Card",
+        "description": "Update a card",
+        "operationId": "put-cards-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the card",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "The new description for the card",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "closed",
+            "in": "query",
+            "description": "Whether the card should be archived (closed: true)",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "idMembers",
+            "in": "query",
+            "description": "Comma-separated list of member IDs",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idAttachmentCover",
+            "in": "query",
+            "description": "The ID of the image attachment the card should use as its cover, or null for none",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idList",
+            "in": "query",
+            "description": "The ID of the list the card should be in",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idLabels",
+            "in": "query",
+            "description": "Comma-separated list of label IDs",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "The ID of the board the card should be on",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the card in its list. `top`, `bottom`, or a positive float",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                { "type": "string", "enum": ["top", "bottom"] },
+                { "type": "number", "format": "float" }
+              ]
+            }
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "When the card is due, or `null`",
+            "required": false,
+            "schema": { "nullable": true, "type": "string", "format": "date" }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "The start date of a card, or `null`",
+            "required": false,
+            "schema": { "nullable": true, "type": "string", "format": "date" }
+          },
+          {
+            "name": "dueComplete",
+            "in": "query",
+            "description": "Whether the due date should be marked complete",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "subscribed",
+            "in": "query",
+            "description": "Whether the member is should be subscribed to the card",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "description": "For use with/by the Map View",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "locationName",
+            "in": "query",
+            "description": "For use with/by the Map View",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "coordinates",
+            "in": "query",
+            "description": "For use with/by the Map View. Should be latitude,longitude",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "cover",
+            "in": "query",
+            "description": "Updates the card's cover\n | Option | Values | About |\n |--------|--------|-------|\n | color | `pink`, `yellow`, `lime`, `blue`, `black`, `orange`, `red`, `purple`, `sky`, `green` | Makes the cover a solid color . |\n | brightness | `dark`, `light` | Determines whether the text on the cover should be dark or light.\n | url | An unsplash URL: https://images.unsplash.com | Used if making an image the cover. Only Unsplash URLs work.\n | idAttachment | ID of an attachment on the card | Used if setting an attached image as the cover. |\n | size | `normal`, `full` | Determines whether to show the card name on the cover, or below it. |\n \n `brightness` can be sent alongside any of the other parameters, but all of the other parameters are mutually exclusive; you can not have the cover be a `color` and an `idAttachment` at the same time. \n \n On the brightness options, setting it to light will make the text on the card cover dark:\n ![](/cloud/trello/images/rest/cards/cover-brightness-dark.png)\n \n And vice versa, setting it to dark will make the text on the card cover light: \n ![](/cloud/trello/images/rest/cards/cover-brightness-light.png) ",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "object",
+                  "description": "An object containing information regarding the card's cover \n `brightness` can be sent alongside any of the other parameters, but all of the other parameters are mutually exclusive; you can not have the cover be a color and an `idAttachment` at the same time.",
+                  "properties": {
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "pink",
+                        "yellow",
+                        "lime",
+                        "blue",
+                        "black",
+                        "orange",
+                        "red",
+                        "purple",
+                        "sky",
+                        "green"
+                      ],
+                      "description": "One of: `pink, yellow, lime, blue, black, orange, red, purple, sky, green`",
+                      "example": "pink"
+                    },
+                    "brightness": {
+                      "type": "string",
+                      "enum": ["dark", "light"],
+                      "description": "Determines whether the text on the cover should be dark or light. Setting it to `light` will make the text on the card cover dark. And vice versa, setting it to dark will make the text on the card cover light"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "url",
+                      "description": "Used if making an image the cover. Only Unsplash URLs (https://images.unsplash.com/) work."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Card" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Card",
+        "description": "Delete a Card",
+        "operationId": "delete-cards-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a field on a Card",
+        "description": "Get a specific property of a card",
+        "operationId": "get-cards-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "The desired field.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/CardFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Card" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/actions": {
+      "get": {
+        "tags": [],
+        "summary": "Get Actions on a Card",
+        "description": "List the Actions on a Card",
+        "operationId": "get-cards-id-actions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "A comma-separated list of [action types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "commentCard, updateCard:idList"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The page of results for actions. Each page of results has 50 actions.",
+            "required": false,
+            "schema": { "type": "number", "maximum": 19, "default": 0 }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Action" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/attachments": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Attachments on a Card",
+        "description": "List the attachments on a card",
+        "operationId": "get-cards-id-attachments",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of attachment [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Use `cover` to restrict to just the cover attachment",
+            "required": false,
+            "schema": { "type": "string", "default": "false" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Attachment" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Attachment On Card",
+        "description": "Create an Attachment to a Card",
+        "operationId": "post-cards-id-attachments",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the attachment. Max length 256.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "description": "The file to attach, as multipart/form-data",
+            "required": false,
+            "schema": { "type": "string", "format": "binary" }
+          },
+          {
+            "name": "mimeType",
+            "in": "query",
+            "description": "The mimeType of the attachment. Max length 256",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "description": "A URL to attach. Must start with `http://` or `https://`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "setCover",
+            "in": "query",
+            "schema": { "type": "boolean", "default": false },
+            "description": "Determines whether to use the new attachment as a cover for the Card."
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Attachment" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/attachments/{idAttachment}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idAttachment",
+          "in": "path",
+          "description": "The ID of the Attachment",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get an Attachment on a Card",
+        "description": "Get a specific Attachment on a Card.",
+        "operationId": "get-cards-id-attachments-idattachment",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "The Attachment fields to be included in the response.",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "$ref": "#/components/schemas/AttachmentFields" }]
+              },
+              "default": ["all"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Attachment" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete an Attachment on a Card",
+        "description": "Delete an Attachment",
+        "operationId": "deleted-cards-id-attachments-idattachment",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idAttachment",
+            "in": "path",
+            "description": "The ID of the attachment to delete",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/board": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Board the Card is on",
+        "description": "Get the board a card is on",
+        "operationId": "get-cards-id-board",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/checkItemStates": {
+      "get": {
+        "tags": [],
+        "summary": "Get checkItems on a Card",
+        "description": "Get the completed checklist items on a card",
+        "operationId": "get-cards-id-checkitemstates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `idCheckItem`, `state`",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/checklists": {
+      "get": {
+        "tags": [],
+        "summary": "Get Checklists on a Card",
+        "description": "Get the checklists on a card",
+        "operationId": "get-cards-id-checklists",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "checkItems",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "all"
+            }
+          },
+          {
+            "name": "checkItem_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `name,nameData,pos,state,type,due,dueReminder,idMember`",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "default": "name,nameData,pos,state,due,dueReminder,idMember",
+              "enum": [
+                "name",
+                "nameData",
+                "pos",
+                "state",
+                "type",
+                "due",
+                "dueReminder",
+                "idMember"
+              ]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "none"]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "explode": false,
+            "style": "form",
+            "description": "`all` or a comma-separated list of: `idBoard,idCard,name,pos`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "name", "nameData", "pos", "state", "type"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Checklist on a Card",
+        "description": "Create a new checklist on a card",
+        "operationId": "post-cards-id-checklists",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the checklist",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idChecklistSource",
+            "in": "query",
+            "description": "The ID of a source checklist to copy into the new one",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the checklist on the card. One of: `top`, `bottom`, or a positive number.",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/checkItem/{idCheckItem}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idCheckItem",
+          "in": "path",
+          "description": "The ID of the checkitem",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get checkItem on a Card",
+        "description": "Get a specific checkItem on a card",
+        "operationId": "get-cards-id-checkitem-idcheckitem",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of `name,nameData,pos,state,type,due,dueReminder,idMember`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "name,nameData,pos,state,due,dueReminder,idMember"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a checkItem on a Card",
+        "description": "Update an item in a checklist on a card.",
+        "operationId": "put-cards-id-checkitem-idcheckitem",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the checklist item",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "One of: `complete`, `incomplete`",
+            "required": false,
+            "schema": { "type": "string", "enum": ["complete", "incomplete"] }
+          },
+          {
+            "name": "idChecklist",
+            "in": "query",
+            "description": "The ID of the checklist this item is in",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "`top`, `bottom`, or a positive float",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "A due date for the checkitem",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "dueReminder",
+            "in": "query",
+            "description": "A dueReminder for the due date on the checkitem",
+            "required": false,
+            "schema": { "type": "number", "nullable": true }
+          },
+          {
+            "name": "idMember",
+            "in": "query",
+            "description": "The ID of the member to remove from the card",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete checkItem on a Card",
+        "description": "Delete a checklist item",
+        "operationId": "delete-cards-id-checkitem-idcheckitem",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/list": {
+      "get": {
+        "tags": [],
+        "summary": "Get the List of a Card",
+        "description": "Get the list a card is in",
+        "operationId": "get-cards-id-list",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/members": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Members of a Card",
+        "description": "Get the members on a card",
+        "operationId": "get-cards-id-members",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/membersVoted": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Members who have voted on a Card",
+        "description": "Get the members who have voted on a card",
+        "operationId": "get-cards-id-membersvoted",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Add Member vote to Card",
+        "description": "Vote on the card for a given member.",
+        "operationId": "cardsidmembersvoted-1",
+        "parameters": [
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The ID of the member to vote 'yes' on the card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/pluginData": {
+      "get": {
+        "tags": [],
+        "summary": "Get pluginData on a Card",
+        "description": "Get any shared pluginData on a card.",
+        "operationId": "get-cards-id-plugindata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/stickers": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Stickers on a Card",
+        "description": "Get the stickers on a card",
+        "operationId": "get-cards-id-stickers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Add a Sticker to a Card",
+        "description": "Add a sticker to a card",
+        "operationId": "post-cards-id-stickers",
+        "parameters": [
+          {
+            "name": "image",
+            "in": "query",
+            "description": "For custom stickers, the id of the sticker. For default stickers, the string identifier (like 'taco-cool', see below)",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "The top position of the sticker, from -60 to 100",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "minimum": -60,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "left",
+            "in": "query",
+            "description": "The left position of the sticker, from -60 to 100",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "minimum": -60,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "zIndex",
+            "in": "query",
+            "description": "The z-index of the sticker",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "rotate",
+            "in": "query",
+            "description": "The rotation of the sticker",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 360
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/stickers/{idSticker}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idSticker",
+          "in": "path",
+          "description": "The ID of the sticker",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Sticker on a Card",
+        "description": "Get a specific sticker on a card",
+        "operationId": "get-cards-id-stickers-idsticker",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of sticker [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Sticker on a Card",
+        "description": "Remove a sticker from the card",
+        "operationId": "delete-cards-id-stickers-idsticker",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Sticker on a Card",
+        "description": "Update a sticker on a card",
+        "operationId": "put-cards-id-stickers-idsticker",
+        "parameters": [
+          {
+            "name": "top",
+            "in": "query",
+            "description": "The top position of the sticker, from -60 to 100",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "minimum": -60,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "left",
+            "in": "query",
+            "description": "The left position of the sticker, from -60 to 100",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "minimum": -60,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "zIndex",
+            "in": "query",
+            "description": "The z-index of the sticker",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "rotate",
+            "in": "query",
+            "description": "The rotation of the sticker",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 360
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/actions/{idAction}/comments": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Card",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idAction",
+          "in": "path",
+          "description": "The ID of the comment action to update",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "put": {
+        "tags": [],
+        "summary": "Update Comment Action on a Card",
+        "description": "Update an existing comment",
+        "operationId": "put-cards-id-actions-idaction-comments",
+        "parameters": [
+          {
+            "name": "text",
+            "in": "query",
+            "description": "The new text for the comment",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a comment on a Card",
+        "description": "Delete a comment",
+        "operationId": "delete-cards-id-actions-id-comments",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{idCard}/customField/{idCustomField}/item": {
+      "put": {
+        "tags": [],
+        "summary": "Update Custom Field item on Card",
+        "description": "Setting, updating, and removing the value for a Custom Field on a card. For more details on updating custom fields check out the [Getting Started With Custom Fields](/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)",
+        "operationId": "put-cards-idcard-customfield-idcustomfield-item",
+        "parameters": [
+          {
+            "name": "idCard",
+            "in": "path",
+            "description": "ID of the card that the Custom Field value should be set/updated for",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idCustomField",
+            "in": "path",
+            "description": "ID of the Custom Field on the card.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "object",
+                        "description": "An object containing the key and value to set for the card's Custom Field value. The key used to set the value should match the type of Custom Field defined.",
+                        "properties": {
+                          "text": { "type": "string" },
+                          "checked": { "type": "boolean" },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2018-03-13T16:00:00.000Z"
+                          },
+                          "number": { "type": "number" }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "idValue": {
+                        "$ref": "#/components/schemas/TrelloID",
+                        "description": "The ID of the option for the list type Custom Field"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/customFieldItems": {
+      "get": {
+        "tags": [],
+        "summary": "Get Custom Field Items for a Card",
+        "description": "Get the custom field items for a card.",
+        "operationId": "get-cards-id-customfielditems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CustomFieldItems" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/actions/comments": {
+      "post": {
+        "tags": [],
+        "summary": "Add a new comment to a Card",
+        "description": "Add a new comment to a card",
+        "operationId": "post-cards-id-actions-comments",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "text",
+            "in": "query",
+            "description": "The comment",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Action" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/idLabels": {
+      "post": {
+        "tags": [],
+        "summary": "Add a Label to a Card",
+        "description": "Add a label to a card",
+        "operationId": "post-cards-id-idlabels",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The ID of the label to add",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/idMembers": {
+      "post": {
+        "tags": [],
+        "summary": "Add a Member to a Card",
+        "description": "Add a member to a card",
+        "operationId": "post-cards-id-idmembers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The ID of the Member to add to the card",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/labels": {
+      "post": {
+        "tags": [],
+        "summary": "Create a new Label on a Card",
+        "description": "Create a new label for the board and add it to the given card.",
+        "operationId": "post-cards-id-labels",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "description": "A valid label color or `null`. See [labels](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "A name for the label",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/markAssociatedNotificationsRead": {
+      "post": {
+        "tags": [],
+        "summary": "Mark a Card's Notifications as read",
+        "description": "Mark notifications about this card as read",
+        "operationId": "post-cards-id-markassociatednotificationsread",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/idLabels/{idLabel}": {
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Label from a Card",
+        "description": "Remove a label from a card",
+        "operationId": "delete-cards-id-idlabels-idlabel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idLabel",
+            "in": "path",
+            "description": "The ID of the label to remove",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/idMembers/{idMember}": {
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Member from a Card",
+        "description": "Remove a member from a card",
+        "operationId": "delete-id-idmembers-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID of the member to remove from the card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{id}/membersVoted/{idMember}": {
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Member's Vote on a Card",
+        "description": "Remove a member's vote from a card",
+        "operationId": "delete-cards-id-membersvoted-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID of the member whose vote to remove",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/cards/{idCard}/checklist/{idChecklist}/checkItem/{idCheckItem}": {
+      "put": {
+        "tags": [],
+        "summary": "Update Checkitem on Checklist on Card",
+        "description": "Update an item in a checklist on a card.",
+        "operationId": "put-cards-idcard-checklist-idchecklist-checkitem-idcheckitem",
+        "parameters": [
+          {
+            "name": "idCard",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idCheckItem",
+            "in": "path",
+            "description": "The ID of the checklist item to update",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "`top`, `bottom`, or a positive float",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          },
+          {
+            "name": "idChecklist",
+            "in": "path",
+            "description": "The ID of the item to update.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CheckItem" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cards/{id}/checklists/{idChecklist}": {
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Checklist on a Card",
+        "description": "Delete a checklist from a card",
+        "operationId": "delete-cards-id-checklists-idchecklist",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Card",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idChecklist",
+            "in": "path",
+            "description": "The ID of the checklist to delete",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Checklist",
+        "description": "",
+        "operationId": "post-checklists",
+        "parameters": [
+          {
+            "name": "idCard",
+            "in": "query",
+            "description": "The ID of the Card that the checklist should be added to.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the checklist. Should be a string of length 1 to 16384.",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 16384, "minLength": 1 }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the checklist on the card. One of: `top`, `bottom`, or a positive number.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          },
+          {
+            "name": "idChecklistSource",
+            "in": "query",
+            "description": "The ID of a checklist to copy into the new checklist.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of a checklist.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Checklist",
+        "description": "",
+        "operationId": "get-checklists-id",
+        "parameters": [
+          {
+            "name": "cards",
+            "in": "query",
+            "description": "Valid values: `all`, `closed`, `none`, `open`, `visible`. Cards is a nested resource. The additional query params available are documented at [Cards Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource).",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "none",
+              "enum": ["all", "closed", "none", "open", "visible"]
+            }
+          },
+          {
+            "name": "checkItems",
+            "in": "query",
+            "description": "The check items on the list to return. One of: `all`, `none`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "all"
+            }
+          },
+          {
+            "name": "checkItem_fields",
+            "in": "query",
+            "description": "The fields on the checkItem to return if checkItems are being returned. `all` or a comma-separated list of: `name`, `nameData`, `pos`, `state`, `type`, `due`, `dueReminder`, `idMember`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "name, nameData, pos, state, due, dueReminder, idMember",
+              "enum": [
+                "all",
+                "name",
+                "nameData",
+                "pos",
+                "state",
+                "type",
+                "due",
+                "dueReminder",
+                "idMember"
+              ]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of checklist [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Checklist",
+        "description": "Update an existing checklist.",
+        "operationId": "put-checlists-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name of the new checklist being created. Should be length of 1 to 16384.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "Determines the position of the checklist on the card. One of: `top`, `bottom`, or a positive number.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Checklist",
+        "description": "Delete a checklist",
+        "operationId": "delete-checklists-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}/{field}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of a checklist.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "field",
+          "in": "path",
+          "description": "Field to update.",
+          "required": true,
+          "schema": { "type": "string", "enum": ["name", "pos"] }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get field on a Checklist",
+        "description": "",
+        "operationId": "get-checklists-id-field",
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update field on a Checklist",
+        "description": "",
+        "operationId": "put-checklists-id-field",
+        "parameters": [
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The value to change the checklist name to. Should be a string of length 1 to 16384.",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/posStringOrNumber" },
+                { "$ref": "#/components/schemas/TrelloID" }
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}/board": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Board the Checklist is on",
+        "description": "",
+        "operationId": "get-checklists-id-board",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of a checklist.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "name"],
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}/cards": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Card a Checklist is on",
+        "description": "",
+        "operationId": "get-checklists-id-cards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of a checklist.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}/checkItems": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of a checklist.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Checkitems on a Checklist",
+        "description": "",
+        "operationId": "get-checklists-id-checkitems",
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of: `all`, `none`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "none"]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "One of: `all`, `name`, `nameData`, `pos`, `state`,`type`, `due`, `dueReminder`, `idMember`.",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "default": "name, nameData, pos, state, due, dueReminder, idMember",
+              "enum": [
+                "all",
+                "name",
+                "nameData",
+                "pos",
+                "state",
+                "type",
+                "due",
+                "dueReminder",
+                "idMember"
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Checkitem on Checklist",
+        "description": "",
+        "operationId": "post-checklists-id-checkitems",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name of the new check item on the checklist. Should be a string of length 1 to 16384.",
+            "required": true,
+            "schema": { "type": "string", "maxLength": 16384, "minLength": 1 }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the check item in the checklist. One of: `top`, `bottom`, or a positive number.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "bottom",
+              "$ref": "#/components/schemas/posStringOrNumber"
+            }
+          },
+          {
+            "name": "checked",
+            "in": "query",
+            "description": "Determines whether the check item is already checked when created.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "A due date for the checkitem",
+            "required": false,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "dueReminder",
+            "in": "query",
+            "description": "A dueReminder for the due date on the checkitem",
+            "required": false,
+            "schema": { "type": "number", "nullable": true }
+          },
+          {
+            "name": "idMember",
+            "in": "query",
+            "description": "An ID of a member resource.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/checklists/{id}/checkItems/{idCheckItem}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of a checklist.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idCheckItem",
+          "in": "path",
+          "description": "ID of the check item to retrieve.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Checkitem on a Checklist",
+        "description": "",
+        "operationId": "get-checklists-id-checkitems-idcheckitem",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "One of: `all`, `name`, `nameData`, `pos`, `state`, `type`, `due`, `dueReminder`, `idMember`,.",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "default": "name, nameData, pos, state, due, dueReminder, idMember",
+              "enum": [
+                "all",
+                "name",
+                "nameData",
+                "pos",
+                "state",
+                "type",
+                "due",
+                "dueReminder",
+                "idMember"
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete Checkitem from Checklist",
+        "description": "Remove an item from a checklist",
+        "operationId": "delete-checklists-id-checkitems-idcheckitem",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/customFields": {
+      "post": {
+        "tags": [],
+        "summary": "Create a new Custom Field on a Board",
+        "description": "Create a new Custom Field on a board.",
+        "operationId": "post-customfields",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["idModel", "modelType", "name", "type", "pos"],
+                "properties": {
+                  "idModel": {
+                    "$ref": "#/components/schemas/TrelloID",
+                    "description": "The ID of the model for which the Custom Field is being defined. This should always be the ID of a board."
+                  },
+                  "modelType": {
+                    "enum": ["board"],
+                    "type": "string",
+                    "description": "The type of model that the Custom Field is being defined on. This should always be `board`."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the Custom Field"
+                  },
+                  "type": {
+                    "enum": ["checkbox", "list", "number", "text", "date"],
+                    "type": "string",
+                    "description": "The type of Custom Field to create."
+                  },
+                  "options": {
+                    "type": "string",
+                    "description": "If the type is `checkbox` "
+                  },
+                  "pos": {
+                    "$ref": "#/components/schemas/posStringOrNumber",
+                    "description": ""
+                  },
+                  "display_cardFront": {
+                    "type": "boolean",
+                    "description": "Whether this Custom Field should be shown on the front of Cards",
+                    "default": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomField" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customFields/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the Custom Field.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Custom Field",
+        "description": "",
+        "operationId": "get-customfields-id",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomField" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Custom Field definition",
+        "description": "Update a Custom Field definition.",
+        "operationId": "put-customfields-id",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the Custom Field"
+                  },
+                  "pos": { "$ref": "#/components/schemas/posStringOrNumber" },
+                  "display/cardFront": {
+                    "type": "boolean",
+                    "description": "Whether to display this custom field on the front of cards"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomField" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Custom Field definition",
+        "description": "Delete a Custom Field from a board.",
+        "operationId": "delete-customfields-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/customFields/{id}/options": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the customfield.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "post": {
+        "tags": [],
+        "summary": "Add Option to Custom Field dropdown",
+        "description": "Add an option to a dropdown Custom Field",
+        "operationId": "get-customfields-id-options",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "get": {
+        "tags": [],
+        "summary": "Get Options of Custom Field drop down",
+        "description": "Get the options of a drop down Custom Field",
+        "operationId": "post-customfields-id-options",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/customFields/{id}/options/{idCustomFieldOption}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the customfielditem.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idCustomFieldOption",
+          "in": "path",
+          "description": "ID of the customfieldoption to retrieve.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Option of Custom Field dropdown",
+        "description": "Retrieve a specific, existing Option on a given dropdown-type Custom Field",
+        "operationId": "get-customfields-options-idcustomfieldoption",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete Option of Custom Field dropdown",
+        "description": "Delete an option from a Custom Field dropdown.",
+        "operationId": "delete-customfields-options-idcustomfieldoption",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/emoji": {
+      "get": {
+        "tags": [],
+        "summary": "List available Emoji",
+        "description": "List available Emoji",
+        "operationId": "emoji",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "query",
+            "description": "The locale to return emoji descriptions and names in. Defaults to the logged in member's locale.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "spritesheets",
+            "in": "query",
+            "description": "`true` to return spritesheet URLs in the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Emoji" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}": {
+      "get": {
+        "tags": [],
+        "summary": "Get an Enterprise",
+        "description": "Get an enterprise by its ID.",
+        "operationId": "get-enterprises-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of: `id`, `name`, `displayName`, `prefs`, `ssoActivationFailed`, `idAdmins`, `idMembers` (Note that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total available result count or pagination status data. Read the SCIM documentation [here]() for more information on filtering), `idOrganizations`, `products`, `userTypes`, `idMembers`, `idOrganizations`",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "members",
+            "in": "query",
+            "description": "One of: `none`, `normal`, `admins`, `owners`, `all`",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "One of: `avatarHash`, `fullName`, `initials`, `username`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash, fullName, initials, username"
+            }
+          },
+          {
+            "name": "member_filter",
+            "in": "query",
+            "description": "Pass a [SCIM-style query](/cloud/trello/scim/) to filter members. This takes precedence over the all/normal/admins value of members. If any of the member_* args are set, the member array will be paginated.",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "member_sort",
+            "in": "query",
+            "description": "This parameter expects a [SCIM-style](/cloud/trello/scim/) sorting value prefixed by a `-` to sort descending. If no `-` is prefixed, it will be sorted ascending. Note that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total available result count or pagination status data.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "member_sortBy",
+            "in": "query",
+            "description": "Deprecated: Please use member_sort. This parameter expects a [SCIM-style sorting value](/cloud/trello/scim/). Note that the members array returned will be paginated if `members` is `normal` or `admins`. Pagination can be controlled with `member_startIndex`, etc, and the API response's header will contain the total count and pagination state.",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "member_sortOrder",
+            "in": "query",
+            "description": "Deprecated: Please use member_sort. One of: `ascending`, `descending`, `asc`, `desc`",
+            "required": false,
+            "schema": { "type": "string", "default": "id" }
+          },
+          {
+            "name": "member_startIndex",
+            "in": "query",
+            "description": "Any integer between 0 and 100.",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "1" }
+          },
+          {
+            "name": "member_count",
+            "in": "query",
+            "description": "0 to 100",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "10" }
+          },
+          {
+            "name": "organizations",
+            "in": "query",
+            "description": "One of: `none`, `members`, `public`, `all`",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested organization field resource]() accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "organization_paid_accounts",
+            "in": "query",
+            "description": "Whether or not to include paid account information in the returned workspace objects",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organization_memberships",
+            "in": "query",
+            "description": "Comma-seperated list of: `me`, `normal`, `admin`, `active`, `deactivated`",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Enterprise" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/auditlog": {
+      "get": {
+        "tags": [],
+        "summary": "Get auditlog data for an Enterprise",
+        "description": "Returns an array of Actions related to the Enterprise object. Used for populating data sent to Google Sheets from an Enterprise's audit log page: https://trello.com/e/{enterprise_name}/admin/auditlog. An Enterprise admin token is required for this route. \n\n NOTE: For enterprises that have opted in to user management via AdminHub, the auditlog will will contain actions taken in AdminHub, but may not contain the source for those actions.",
+        "operationId": "get-enterprises-id-auditlog",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/EnterpriseAuditLog" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/admins": {
+      "get": {
+        "tags": [],
+        "summary": "Get Enterprise admin Members",
+        "description": "Get an enterprise's admin members.",
+        "operationId": "get-enterprises-id-admins",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Any valid value that the [nested member field resource]() accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "fullName, userName" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EnterpriseAdmin" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/signupUrl": {
+      "get": {
+        "tags": [],
+        "summary": "Get signupUrl for Enterprise",
+        "description": "Get the signup URL for an enterprise.",
+        "operationId": "get-enterprises-id-signupurl",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "authenticate",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "confirmationAccepted",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "returnUrl",
+            "in": "query",
+            "description": "Any valid URL.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "url",
+              "default": null,
+              "nullable": true
+            }
+          },
+          {
+            "name": "tosAccepted",
+            "in": "query",
+            "description": "Designates whether the user has seen/consented to the Trello ToS prior to being redirected to the enterprise signup page/their IdP.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "signupUrl": { "type": "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/members": {
+      "get": {
+        "tags": [],
+        "summary": "Get Members of Enterprise",
+        "description": "Get the members of an enterprise.",
+        "operationId": "get-enterprises-id-members",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "A comma-seperated list of valid [member fields](/cloud/trello/guides/rest-api/object-definitions/#member-object).",
+            "schema": {
+              "type": "string",
+              "default": "avatarHash, fullName, initials, username"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Pass a [SCIM-style query](/cloud/trello/scim/) to filter members. This takes precedence over the all/normal/admins value of members. If any of the below member_* args are set, the member array will be paginated.",
+            "required": false,
+            "schema": { "type": "string", "nullable": true }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "This parameter expects a [SCIM-style](/cloud/trello/scim/) sorting value prefixed by a `-` to sort descending. If no `-` is prefixed, it will be sorted ascending. Note that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total available result count or pagination status data.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "Deprecated: Please use `sort` instead. This parameter expects a [SCIM-style](/cloud/trello/scim/) sorting value. Note that the members array returned will be paginated if `members` is 'normal' or 'admins'. Pagination can be controlled with member_startIndex, etc, but the API response will not contain the total available result count or pagination status data.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "description": "Deprecated: Please use `sort` instead. One of: `ascending`, `descending`, `asc`, `desc`.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["ascending", "descending", "asc", "desc", null],
+              "default": null,
+              "nullable": true
+            }
+          },
+          {
+            "name": "startIndex",
+            "in": "query",
+            "description": "Any integer between 0 and 9999.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0,
+              "maximum": 9999
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "[SCIM-style filter](/cloud/trello/scim/).",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested organization field resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "displayName" }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "name" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Member" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/members/{idMember}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Member of Enterprise",
+        "description": "Get a specific member of an enterprise by ID.",
+        "operationId": "get-enterprises-id-members-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "An ID of a member resource.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "A comma separated list of any valid values that the [nested member field resource]() accepts.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash, fullName, initials, username"
+            }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested organization field resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "displayName" }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "schema": { "type": "string", "default": "name" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/transferrable/organization/{idOrganization}": {
+      "get": {
+        "tags": [],
+        "summary": "Get whether an organization can be transferred to an enterprise.",
+        "description": "Get whether an organization can be transferred to an enterprise.",
+        "operationId": "get-enterprises-id-transferrable-organization-idOrganization",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganization",
+            "in": "path",
+            "description": "An ID of an Organization resource.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferrableOrganization"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/transferrable/bulk/{idOrganizations}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a bulk list of organizations that can be transferred to an enterprise.",
+        "description": "Get a list of organizations that can be transferred to an enterprise when given a bulk list of organizations.",
+        "operationId": "get-enterprises-id-transferrable-bulk-idOrganizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganizations",
+            "in": "path",
+            "description": "An array of IDs of an Organization resource.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "$ref": "#/components/schemas/Organization" }]
+              }
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/TransferrableOrganization"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/${id}/enterpriseJoinRequest/bulk": {
+      "put": {
+        "tags": [],
+        "summary": "Decline enterpriseJoinRequests from one organization or a bulk list of organizations.",
+        "description": "Decline enterpriseJoinRequests from one organization or bulk amount of organizations",
+        "operationId": "put-enterprises-id-enterpriseJoinRequest-bulk",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganizations",
+            "in": "query",
+            "description": "An array of IDs of an Organization resource.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "$ref": "#/components/schemas/Organization" }]
+              }
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": { "description": "Success" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/claimableOrganizations": {
+      "get": {
+        "tags": [],
+        "summary": "Get ClaimableOrganizations of an Enterprise",
+        "description": "Get the Workspaces that are claimable by the enterprise by ID. Can optionally query for workspaces based on activeness/ inactiveness.",
+        "operationId": "get-enterprises-id-claimableOrganizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limits the number of workspaces to be sorted",
+            "required": false,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Specifies the sort order to return matching documents",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name of the enterprise to retrieve workspaces for",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "activeSince",
+            "in": "query",
+            "description": "Date in YYYY-MM-DD format indicating the date to search up to for activeness of workspace",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "inactiveSince",
+            "in": "query",
+            "description": "Date in YYYY-MM-DD format indicating the date to search up to for inactiveness of workspace",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimableOrganizations"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected erorr",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/pendingOrganizations": {
+      "get": {
+        "tags": [],
+        "summary": "Get PendingOrganizations of an Enterprise",
+        "description": "Get the Workspaces that are pending for the enterprise by ID.",
+        "operationId": "get-enterprises-id-pendingOrganizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "activeSince",
+            "in": "query",
+            "description": "Date in YYYY-MM-DD format indicating the date to search up to for activeness of workspace",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "inactiveSince",
+            "in": "query",
+            "description": "Date in YYYY-MM-DD format indicating the date to search up to for inactiveness of workspace",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PendingOrganizations"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected erorr",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/tokens": {
+      "post": {
+        "tags": [],
+        "summary": "Create an auth Token for an Enterprise.",
+        "description": "Create an auth Token for an Enterprise.",
+        "operationId": "post-enterprises-id-tokens",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "expiration",
+            "in": "query",
+            "description": "One of: `1hour`, `1day`, `30days`, `never`",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/enterprises/{id}/organizations": {
+      "put": {
+        "tags": [],
+        "summary": "Transfer an Organization to an Enterprise.",
+        "description": "Transfer an organization to an enterprise.\n\n NOTE: For enterprises that have opted in to user management via AdminHub, this endpoint will result in the organization being added to the enterprise asynchronously. A 200 response only indicates receipt of the request, it does not indicate successful addition to the enterprise.",
+        "operationId": "put-enterprises-id-organizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganization",
+            "in": "query",
+            "description": "ID of Organization to be transferred to Enterprise.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [{ "$ref": "#/components/schemas/Organization" }]
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/members/{idMember}/licensed": {
+      "put": {
+        "summary": "Update a Member's licensed status",
+        "description": "This endpoint is used to update whether the provided Member should use one of the Enterprise's available licenses or not. Revoking a license will deactivate a Member of an Enterprise. \n\n NOTE: Revoking of licenses is not possible for enterprises that have opted in to user management via AdminHub.",
+        "operationId": "put-enterprises-id-members-idmember-licensed",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID of the Member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Boolean value to determine whether the user should be given an Enterprise license (true) or not (false).",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enterprises/{id}/members/{idMember}/deactivated": {
+      "put": {
+        "tags": [],
+        "summary": "Deactivate a Member of an Enterprise.",
+        "description": "Deactivate a Member of an Enterprise.\n\n NOTE: Deactivation is not possible for enterprises that have opted in to user management via AdminHub.",
+        "operationId": "enterprises-id-members-idMember-deactivated",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "ID of the Member to deactive.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Determines whether the user is deactivated or not.",
+            "required": true,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "A comma separated list of any valid values that the [nested member field resource]() accepts.",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "avatarHash, fullName, initials, username"
+            }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested organization resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "displayName"
+            }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "description": "Any valid value that the [nested board resource](/cloud/trello/guides/rest-api/nested-resources/) accepts.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "name"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/enterprises/{id}/admins/{idMember}": {
+      "put": {
+        "tags": [],
+        "summary": "Update Member to be admin of Enterprise",
+        "description": "Make Member an admin of Enterprise.\n\n NOTE: This endpoint is not available to enterprises that have opted in to user management via AdminHub.",
+        "operationId": "put-enterprises-id-admins-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "ID of member to be made an admin of enterprise.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Member as admin from Enterprise.",
+        "description": "Remove a member as admin from an enterprise.\n\n NOTE: This endpoint is not available to enterprises that have opted in to user management via AdminHub.",
+        "operationId": "enterprises-id-organizations-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "ID of the member to be removed as an admin from enterprise.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/enterprises/{id}/organizations/{idOrg}": {
+      "delete": {
+        "tags": [],
+        "summary": "Delete an Organization from an Enterprise.",
+        "description": "Remove an organization from an enterprise.",
+        "operationId": "delete-enterprises-id-organizations-idorg",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrg",
+            "in": "path",
+            "description": "ID of the organization to be removed from the enterprise.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/enterprises/{id}/organizations/bulk/{idOrganizations}": {
+      "get": {
+        "tags": [],
+        "summary": "Bulk accept a set of organizations to an Enterprise.",
+        "description": "Accept an array of organizations to an enterprise.\n\n NOTE: For enterprises that have opted in to user management via AdminHub, this endpoint will result in organizations being added to the enterprise asynchronously. A 200 response only indicates receipt of the request, it does not indicate successful addition to the enterprise.",
+        "operationId": "get-enterprises-id-organizations-bulk-idOrganizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the enterprise to retrieve.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganizations",
+            "in": "path",
+            "description": "An array of IDs of the organizations to be removed from the enterprise.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "$ref": "#/components/schemas/Organization" }]
+              }
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": { "description": "Success" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "default": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/labels/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the Label",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Label",
+        "description": "Get information about a single Label.",
+        "operationId": "get-labels-id",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "all or a comma-separated list of [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Label",
+        "description": "Update a label by ID.",
+        "operationId": "put-labels-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the label",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "description": "The new color for the label. See: [fields](/cloud/trello/guides/rest-api/object-definitions/) for color options",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/Color" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Label",
+        "description": "Delete a label by ID.",
+        "operationId": "delete-labels-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/labels/{id}/{field}": {
+      "put": {
+        "tags": [],
+        "summary": "Update a field on a label",
+        "description": "Update a field on a label.",
+        "operationId": "put-labels-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the label",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "The field on the Label to update.",
+            "required": true,
+            "schema": { "type": "string", "enum": ["color", "name"] }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The new value for the field.",
+            "schema": { "$ref": "#/components/schemas/TrelloID" },
+            "required": true
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/labels": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Label",
+        "description": "Create a new Label on a Board.",
+        "operationId": "post-labels",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name for the label",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "description": "The color for the label.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/Color" }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "The ID of the Board to create the Label on.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the list",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a List",
+        "description": "Get information about a List",
+        "operationId": "get-lists-id",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "description": "`all` or a comma separated list of List field names.",
+            "required": false,
+            "schema": { "type": "string", "default": "name,closed,idBoard,pos" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a List",
+        "description": "Update the properties of a List",
+        "operationId": "put-lists-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "New name for the list",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "closed",
+            "in": "query",
+            "description": "Whether the list should be closed (archived)",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "ID of a board the list should be moved to",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "New position for the list: `top`, `bottom`, or a positive floating point number",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                { "type": "number", "format": "float" },
+                { "type": "string", "enum": ["top", "bottom"] }
+              ]
+            }
+          },
+          {
+            "name": "subscribed",
+            "in": "query",
+            "description": "Whether the active member is subscribed to this list",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists": {
+      "post": {
+        "tags": [],
+        "summary": "Create a new List",
+        "description": "Create a new List on a Board",
+        "operationId": "post-lists",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name for the list",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "The long ID of the board the list should be created on",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idListSource",
+            "in": "query",
+            "description": "ID of the List to copy into the new List",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "Position of the list. `top`, `bottom`, or a positive floating point number",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                { "type": "number", "format": "float" },
+                { "type": "string", "enum": ["top", "bottom"] }
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/archiveAllCards": {
+      "post": {
+        "tags": [],
+        "summary": "Archive all Cards in List",
+        "description": "Archive all cards in a list",
+        "operationId": "post-lists-id-archiveallcards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/moveAllCards": {
+      "post": {
+        "tags": [],
+        "summary": "Move all Cards in List",
+        "description": "Move all Cards in a List",
+        "operationId": "post-lists-id-moveallcards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "The ID of the board the cards should be moved to",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idList",
+            "in": "query",
+            "description": "The ID of the list that the cards should be moved to",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/closed": {
+      "put": {
+        "tags": [],
+        "summary": "Archive or unarchive a list",
+        "description": "Archive or unarchive a list",
+        "operationId": "put-lists-id-closed",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "Set to true to close (archive) the list",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/idBoard": {
+      "put": {
+        "tags": [],
+        "summary": "Move List to Board",
+        "description": "Move a List to a different Board",
+        "operationId": "put-id-idboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The ID of the board to move the list to",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/{field}": {
+      "put": {
+        "tags": [],
+        "summary": "Update a field on a List",
+        "description": "Rename a list",
+        "operationId": "put-lists-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "The field on the List to be updated",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["name", "pos", "subscribed"]
+            }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The new value for the field",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The new name for the List"
+                },
+                {
+                  "type": "number",
+                  "format": "float",
+                  "description": "The new position for the List"
+                },
+                {
+                  "type": "string",
+                  "enum": ["top", "bottom"],
+                  "description": "The new position for the List"
+                },
+                { "type": "boolean" }
+              ]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/actions": {
+      "get": {
+        "tags": [],
+        "summary": "Get Actions for a List",
+        "description": "Get the Actions on a List",
+        "operationId": "get-lists-id-actions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "A comma-separated list of [action types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/board": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Board a List is on",
+        "description": "Get the board a list is on",
+        "operationId": "get-lists-id-board",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/#board-object)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/lists/{id}/cards": {
+      "get": {
+        "tags": [],
+        "summary": "Get Cards in a List",
+        "description": "List the cards in a list",
+        "operationId": "get-lists-id-cards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the list",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Card" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Member",
+        "description": "Get a member",
+        "operationId": "get-members=id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TrelloID" },
+                { "type": "string" }
+              ]
+            }
+          },
+          {
+            "name": "actions",
+            "in": "query",
+            "description": "See the [Actions Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#actions-nested-resource)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "boards",
+            "in": "query",
+            "description": "See the [Boards Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#boards-nested-resource)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "boardBackgrounds",
+            "in": "query",
+            "description": "One of: `all`, `custom`, `default`, `none`, `premium`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "custom", "default", "none", "premium"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "boardsInvited",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: closed, members, open, organization, pinned, public, starred, unpinned",
+            "required": false,
+            "schema": {
+              "enum": [
+                "closed",
+                "members",
+                "open",
+                "organization",
+                "pinned",
+                "public",
+                "starred",
+                "unpinned"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "boardsInvited_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "name,closed,idOrganization,pinned"
+            }
+          },
+          {
+            "name": "boardStars",
+            "in": "query",
+            "description": "Whether to return the boardStars or not",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "cards",
+            "in": "query",
+            "description": "See the [Cards Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#cards-nested-resource) for additional options",
+            "required": false,
+            "schema": { "type": "string", "default": "none" }
+          },
+          {
+            "name": "customBoardBackgrounds",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "customEmoji",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "customStickers",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "notifications",
+            "in": "query",
+            "description": "See the [Notifications Nested Resource](/cloud/trello/guides/rest-api/nested-resources/#notifications-nested-resource)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "organizations",
+            "in": "query",
+            "description": "One of: `all`, `members`, `none`, `public`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "members", "none", "public"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "organization_paid_account",
+            "in": "query",
+            "description": "Whether or not to include paid account information in the returned workspace object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organizationsInvited",
+            "in": "query",
+            "description": "One of: `all`, `members`, `none`, `public`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "members", "none", "public"],
+              "default": "none"
+            }
+          },
+          {
+            "name": "organizationsInvited_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "paid_account",
+            "in": "query",
+            "description": "Whether or not to include paid account information in the returned member object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false },
+            "deprecated": true
+          },
+          {
+            "name": "savedSearches",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "tokens",
+            "in": "query",
+            "description": "`all` or `none`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "none"],
+              "default": "none"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Member",
+        "description": "Update a Member",
+        "operationId": "put-members-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fullName",
+            "in": "query",
+            "description": "New name for the member. Cannot begin or end with a space.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "initials",
+            "in": "query",
+            "description": "New initials for the member. 1-4 characters long.",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 4, "minLength": 1 }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "New username for the member. At least 3 characters long, only lowercase letters, underscores, and numbers. Must be unique.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "bio",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "avatarSource",
+            "in": "query",
+            "description": "One of: `gravatar`, `none`, `upload`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["gravatar", "none", "upload"]
+            }
+          },
+          {
+            "name": "prefs/colorBlind",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "prefs/locale",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/minutesBetweenSummaries",
+            "in": "query",
+            "description": "`-1` for disabled, `1`, or `60`",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a field on a Member",
+        "description": "Get a particular property of a member",
+        "operationId": "get-members-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "One of the member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/MemberFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/actions": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's Actions",
+        "description": "List the actions for a member",
+        "operationId": "get-members-id-actions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "A comma-separated list of [action types](https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/).",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/boardBackgrounds": {
+      "get": {
+        "tags": [],
+        "summary": "Get Member's custom Board backgrounds",
+        "description": "Get a member's custom board backgrounds",
+        "operationId": "get-members-id-boardbackgrounds",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of: `all`, `custom`, `default`, `none`, `premium`",
+            "required": false,
+            "schema": {
+              "enum": ["all", "custom", "default", "none", "premium"],
+              "type": "string",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/BoardBackground" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Upload new boardBackground for Member",
+        "description": "Upload a new boardBackground",
+        "operationId": "post-members-id-boardbackgrounds-1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string", "format": "binary" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/BoardBackground" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/boardBackgrounds/{idBackground}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idBackground",
+          "in": "path",
+          "description": "The ID of the board background",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a boardBackground of a Member",
+        "description": "Get a member's board background",
+        "operationId": "get-members-id-boardbackgrounds-idbackground",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `brightness`, `fullSizeUrl`, `scaled`, `tile`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "brightness", "fullSizeUrl", "scaled", "tile"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardBackground" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Member's custom Board background",
+        "description": "Update a board background",
+        "operationId": "put-members-id-boardbackgrounds-idbackground",
+        "parameters": [
+          {
+            "name": "brightness",
+            "in": "query",
+            "description": "One of: `dark`, `light`, `unknown`",
+            "required": false,
+            "schema": { "enum": ["dark", "light", "unknown"], "type": "string" }
+          },
+          {
+            "name": "tile",
+            "in": "query",
+            "description": "Whether the background should be tiled",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardBackground" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Member's custom Board background",
+        "description": "Delete a board background",
+        "operationId": "delete-members-id-boardbackgrounds-idbackground",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/boardStars": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's boardStars",
+        "description": "List a member's board stars",
+        "operationId": "get-members-id-boardstars",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Star for Board",
+        "description": "Star a new board on behalf of a Member",
+        "operationId": "post-members-id-boardstars",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TrelloID" },
+                { "type": "string" }
+              ]
+            }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "The ID of the board to star",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the newly starred board. `top`, `bottom`, or a positive float.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BoardStars" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/boardStars/{idStar}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idStar",
+          "in": "path",
+          "description": "The ID of the board star",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a boardStar of Member",
+        "description": "Get a specific boardStar",
+        "operationId": "get-members-id-boardstars-idstar",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardStars" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update the position of a boardStar of Member",
+        "description": "Update the position of a starred board",
+        "operationId": "put-members-id-boardstars-idstar",
+        "parameters": [
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "New position for the starred board. `top`, `bottom`, or a positive float.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete Star for Board",
+        "description": "Unstar a board",
+        "operationId": "delete-members-id-boardstars-idstar",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/boards": {
+      "get": {
+        "tags": [],
+        "summary": "Get Boards that Member belongs to",
+        "description": "Lists the boards that the user is a member of.",
+        "operationId": "get-members-id-boards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `closed`, `members`, `open`, `organization`, `public`, `starred`",
+            "required": false,
+            "schema": {
+              "enum": [
+                "all",
+                "closed",
+                "members",
+                "open",
+                "organization",
+                "public",
+                "starred"
+              ],
+              "type": "string",
+              "default": "all"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "lists",
+            "in": "query",
+            "description": "Which lists to include with the boards. One of: `all`, `closed`, `none`, `open`",
+            "required": false,
+            "schema": {
+              "enum": ["all", "closed", "none", "open"],
+              "type": "string",
+              "default": "none"
+            }
+          },
+          {
+            "name": "organization",
+            "in": "query",
+            "description": "Whether to include the Organization object with the Boards",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "explode": false,
+            "style": "form",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "name,displayName"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Board" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/boardsInvited": {
+      "get": {
+        "tags": [],
+        "summary": "Get Boards the Member has been invited to",
+        "description": "Get the boards the member has been invited to",
+        "operationId": "get-members-id-boardsinvited",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Board" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/cards": {
+      "get": {
+        "tags": [],
+        "summary": "Get Cards the Member is on",
+        "description": "Gets the cards a member is on",
+        "operationId": "get-members-id-cards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of: `all`, `closed`, `none`, `open`, `visible`",
+            "required": false,
+            "schema": {
+              "enum": ["all", "closed", "none", "open", "visible"],
+              "type": "string",
+              "default": "visible"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Card" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/customBoardBackgrounds": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's custom Board Backgrounds",
+        "description": "Get a member's custom board backgrounds",
+        "operationId": "get-members-id-customboardbackgrounds",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BoardBackground" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create a new custom Board Background",
+        "description": "Upload a new custom board background",
+        "operationId": "membersidcustomboardbackgrounds-1",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string", "format": "binary" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardBackground" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/customBoardBackgrounds/{idBackground}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TrelloID" },
+              { "type": "string" }
+            ]
+          }
+        },
+        {
+          "name": "idBackground",
+          "in": "path",
+          "description": "The ID of the custom background",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get custom Board Background of Member",
+        "description": "Get a specific custom board background",
+        "operationId": "get-members-id-customboardbackgrounds-idbackground",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardBackground" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update custom Board Background of Member",
+        "description": "Update a specific custom board background",
+        "operationId": "put-members-id-customboardbackgrounds-idbackground",
+        "parameters": [
+          {
+            "name": "brightness",
+            "in": "query",
+            "description": "One of: `dark`, `light`, `unknown`",
+            "required": false,
+            "schema": { "enum": ["dark", "light", "unknown"], "type": "string" }
+          },
+          {
+            "name": "tile",
+            "in": "query",
+            "description": "Whether to tile the background",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BoardBackground" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete custom Board Background of Member",
+        "description": "Delete a specific custom board background",
+        "operationId": "delete-members-id-customboardbackgrounds-idbackground",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/customEmoji": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's customEmojis",
+        "description": "Get a Member's uploaded custom Emojis",
+        "operationId": "get-members-id-customemoji",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CustomEmoji" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create custom Emoji for Member",
+        "description": "Create a new custom Emoji",
+        "operationId": "post-members-id-customemoji",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string", "format": "binary" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name for the emoji. 2 - 64 characters",
+            "required": true,
+            "schema": { "type": "string", "minLength": 2, "maxLength": 64 }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomEmoji" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/customEmoji/{idEmoji}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's custom Emoji",
+        "description": "Get a Member's custom Emoji",
+        "operationId": "membersidcustomemojiidemoji",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idEmoji",
+            "in": "path",
+            "description": "The ID of the custom emoji",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of `name`, `url`",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "enum": ["name", "url", "all"],
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomEmoji" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/customStickers": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Member's custom Stickers",
+        "description": "Get a Member's uploaded stickers",
+        "operationId": "get-members-id-customstickers",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CustomSticker" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create custom Sticker for Member",
+        "description": "Upload a new custom sticker",
+        "operationId": "post-members-id-customstickers",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string", "format": "binary" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomSticker" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/customStickers/{idSticker}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        },
+        {
+          "name": "idSticker",
+          "in": "path",
+          "description": "The ID of the uploaded sticker",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's custom Sticker",
+        "description": "Get a Member's custom Sticker",
+        "operationId": "get-members-id-customstickers-idsticker",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of `scaled`, `url`",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "enum": ["scaled", "url", "all"],
+              "type": "string",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CustomSticker" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Member's custom Sticker",
+        "description": "Delete a Member's custom Sticker",
+        "operationId": "delete-members-id-customstickers-idsticker",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/notifications": {
+      "get": {
+        "tags": [],
+        "summary": "Get Member's Notifications",
+        "description": "Get a member's notifications",
+        "operationId": "get-members-id-notifications",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "entities",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "display",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "read_filter",
+            "in": "query",
+            "description": "One of: `all`, `read`, `unread`",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of notification [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max 1000",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "50" }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Max 100",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "0" }
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A notification ID",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "A notification ID",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "memberCreator",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "memberCreator_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Notification" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/organizations": {
+      "get": {
+        "tags": [],
+        "summary": "Get Member's Organizations",
+        "description": "Get a member's Workspaces",
+        "operationId": "get-members-id-organizations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "One of: `all`, `members`, `none`, `public` (Note: `members` filters to only private Workspaces)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "members", "none", "public"]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "paid_account",
+            "in": "query",
+            "description": "Whether or not to include paid account information in the returned workspace object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Organization" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/organizationsInvited": {
+      "get": {
+        "tags": [],
+        "summary": "Get Organizations a Member has been invited to",
+        "description": "Get a member's Workspaces they have been invited to",
+        "operationId": "get-members-id-organizationsinvited",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Organization" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/savedSearches": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Member's saved searched",
+        "description": "List the saved searches of a Member",
+        "operationId": "get-members-id-savedsearches",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/SavedSearch" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create saved Search for Member",
+        "description": "Create a saved search",
+        "operationId": "post-members-id-savedsearches",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The name for the saved search",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The search query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "The position of the saved search. `top`, `bottom`, or a positive float.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/posStringOrNumber" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SavedSearch" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/savedSearches/{idSearch}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "idSearch",
+          "in": "path",
+          "description": "The ID of the saved search to delete",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a saved search",
+        "description": "Get a saved search",
+        "operationId": "get-members-id-savedsearches-idsearch",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SavedSearch" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a saved search",
+        "description": "Update a saved search",
+        "operationId": "put-members-id-savedsearches-idsearch",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "The new name for the saved search",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The new search query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "pos",
+            "in": "query",
+            "description": "New position for saves search. `top`, `bottom`, or a positive float.",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SavedSearch" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a saved search",
+        "description": "Delete a saved search",
+        "operationId": "delete-members-id-savedsearches-idsearch",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/tokens": {
+      "get": {
+        "tags": [],
+        "summary": "Get Member's Tokens",
+        "description": "List a members app tokens",
+        "operationId": "get-members-id-tokens",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "webhooks",
+            "in": "query",
+            "description": "Whether to include webhooks",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Token" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/avatar": {
+      "post": {
+        "tags": [],
+        "summary": "Create Avatar for Member",
+        "description": "Create a new avatar for a member",
+        "operationId": "membersidavatar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string", "format": "binary" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/oneTimeMessagesDismissed": {
+      "post": {
+        "tags": [],
+        "summary": "Dismiss a message for Member",
+        "description": "Dismiss a message",
+        "operationId": "post-members-id-onetimemessagesdismissed",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or username of the member",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "The message to dismiss",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/members/{id}/notificationsChannelSettings": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TrelloID" },
+              { "type": "string" }
+            ]
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Member's notification channel settings",
+        "description": "Get a member's notification channel settings",
+        "operationId": "get-members-id-notificationChannelSettings",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationChannelSettings"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update blocked notification keys of Member on a channel",
+        "description": "Update blocked notification keys of Member on a specific channel",
+        "operationId": "put-members-id-notificationChannelSettings-channel-blockedKeys",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["channel", "blockedKeys"],
+                "properties": {
+                  "channel": { "$ref": "#/components/schemas/Channel" },
+                  "blockedKeys": {
+                    "description": "Blocked key or array of blocked keys.",
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/BlockedKey" },
+                      {
+                        "type": "array",
+                        "items": { "$ref": "#/components/schemas/BlockedKey" }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationChannelSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/notificationsChannelSettings/{channel}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TrelloID" },
+              { "type": "string" }
+            ]
+          }
+        },
+        {
+          "name": "channel",
+          "in": "path",
+          "description": "Channel to block notifications on",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/Channel" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get blocked notification keys of Member on this channel",
+        "description": "Get blocked notification keys of Member on a specific channel",
+        "operationId": "get-members-id-notificationChannelSettings-channel",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationChannelSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update blocked notification keys of Member on a channel",
+        "description": "Update blocked notification keys of Member on a specific channel",
+        "operationId": "put-members-id-notificationChannelSettings-channel-blockedKeys",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["blockedKeys"],
+                "properties": {
+                  "blockedKeys": {
+                    "description": "Singular key or array of notification keys",
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/BlockedKey" },
+                      {
+                        "type": "array",
+                        "items": { "$ref": "#/components/schemas/BlockedKey" }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationChannelSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/members/{id}/notificationsChannelSettings/{channel}/{blockedKeys}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or username of the member",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TrelloID" },
+              { "type": "string" }
+            ]
+          }
+        },
+        {
+          "name": "channel",
+          "in": "path",
+          "description": "Channel to block notifications on",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/Channel" }
+        },
+        {
+          "name": "blockedKeys",
+          "in": "path",
+          "description": "Singular key or comma-separated list of notification keys",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/BlockedKey" }
+        }
+      ],
+      "put": {
+        "tags": [],
+        "summary": "Update blocked notification keys of Member on a channel",
+        "description": "Update blocked notification keys of Member on a specific channel",
+        "operationId": "put-members-id-notificationChannelSettings-channel-blockedKeys",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationChannelSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Notification",
+        "description": "",
+        "operationId": "get-notifications-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "board",
+            "in": "query",
+            "description": "Whether to include the board object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "name"
+            }
+          },
+          {
+            "name": "card",
+            "in": "query",
+            "description": "Whether to include the card object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/CardFields",
+              "default": "name"
+            }
+          },
+          {
+            "name": "display",
+            "in": "query",
+            "description": "Whether to include the display object with the results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "entities",
+            "in": "query",
+            "description": "Whether to include the entities object with the results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of notification [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/NotificationFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "list",
+            "in": "query",
+            "description": "Whether to include the list object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Whether to include the member object",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          },
+          {
+            "name": "memberCreator",
+            "in": "query",
+            "description": "Whether to include the member object of the creator",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "memberCreator_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "avatarHash,fullName,initials,username"
+            }
+          },
+          {
+            "name": "organization",
+            "in": "query",
+            "description": "Whether to include the organization object",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "displayName"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Notification" }]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Notification's read status",
+        "description": "Update the read status of a notification",
+        "operationId": "put-notifications-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "unread",
+            "in": "query",
+            "description": "Whether the notification should be marked as read or not",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Notification" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a field of a Notification",
+        "description": "Get a specific property of a notification",
+        "operationId": "get-notifications-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "A notification [field](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/NotificationFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Notification" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/all/read": {
+      "post": {
+        "tags": [],
+        "summary": "Mark all Notifications as read",
+        "description": "Mark all notifications as read",
+        "operationId": "post-notifications-all-read",
+        "parameters": [
+          {
+            "name": "read",
+            "in": "query",
+            "description": "Boolean to specify whether to mark as read or unread (defaults to `true`, marking as read)",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "explode": false,
+            "style": "form",
+            "description": "A comma-seperated list of IDs. Allows specifying an array of notification IDs to change the read state for. This will become useful as we add grouping of notifications to the UI, with a single button to mark all notifications in the group as read/unread.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/components/schemas/TrelloID" }
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Notification" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/unread": {
+      "put": {
+        "tags": [],
+        "summary": "Update Notification's read status",
+        "description": "Update Notification's read status",
+        "operationId": "put-notifications-id-unread",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Notification" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/board": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Board a Notification is on",
+        "description": "Get the board a notification is associated with",
+        "operationId": "get-notifications-id-board",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board[fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "explode": false,
+            "style": "form",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BoardFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Board" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/card": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Card a Notification is on",
+        "description": "Get the card a notification is associated with",
+        "operationId": "get-notifications-id-card",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "explode": false,
+            "style": "form",
+            "description": "`all` or a comma-separated list of card [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CardFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "oneOf": [{ "$ref": "#/components/schemas/Card" }] }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/list": {
+      "get": {
+        "tags": [],
+        "summary": "Get the List a Notification is on",
+        "description": "Get the list a notification is associated with",
+        "operationId": "get-notifications-id-list",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of list [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ListFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/TrelloList" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/member": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Member a Notification is about (not the creator)",
+        "description": "Get the member (not the creator) a notification is about",
+        "operationId": "notificationsidmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/memberCreator": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Member who created the Notification",
+        "description": "Get the member who created the notification",
+        "operationId": "get-notifications-id-membercreator",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of member [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/organization": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Notification's associated Organization",
+        "description": "Get the organization a notification is associated with",
+        "operationId": "get-notifications-id-organization",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the notification",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of organization [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "explode": false,
+            "style": "form",
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Organization" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations": {
+      "post": {
+        "tags": [],
+        "summary": "Create a new Organization",
+        "description": "Create a new Workspace",
+        "operationId": "post-organizations",
+        "parameters": [
+          {
+            "name": "displayName",
+            "in": "query",
+            "description": "The name to display for the Organization",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "The description for the organizations",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "A string with a length of at least 3. Only lowercase letters, underscores, and numbers are allowed. If the name contains invalid characters, they will be removed. If the name conflicts with an existing name, a new name will be substituted.",
+            "required": false,
+            "schema": { "type": "string", "minLength": 3 }
+          },
+          {
+            "name": "website",
+            "in": "query",
+            "description": "A URL starting with `http://` or `https://`",
+            "required": false,
+            "schema": { "type": "string", "format": "url" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Organization" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or name of the Organization",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get an Organization",
+        "description": "",
+        "operationId": "get-organizations-id",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update an Organization",
+        "description": "Update an organization",
+        "operationId": "put-organizations-id",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "A new name for the organization. At least 3 lowercase letters, underscores, and numbers. Must be unique",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "displayName",
+            "in": "query",
+            "description": "A new displayName for the organization. Must be at least 1 character long and not begin or end with a space.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "desc",
+            "in": "query",
+            "description": "A new description for the organization",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "website",
+            "in": "query",
+            "description": "A URL starting with `http://`, `https://`, or `null`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/associatedDomain",
+            "in": "query",
+            "description": "The Google Apps domain to link this org to.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/externalMembersDisabled",
+            "in": "query",
+            "description": "Whether non-workspace members can be added to boards inside the Workspace",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "prefs/googleAppsVersion",
+            "in": "query",
+            "description": "`1` or `2`",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          },
+          {
+            "name": "prefs/boardVisibilityRestrict/org",
+            "in": "query",
+            "description": "Who on the Workspace can make Workspace visible boards. One of `admin`, `none`, `org`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/boardVisibilityRestrict/private",
+            "in": "query",
+            "description": "Who can make private boards. One of: `admin`, `none`, `org`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/boardVisibilityRestrict/public",
+            "in": "query",
+            "description": "Who on the Workspace can make public boards. One of: `admin`, `none`, `org`",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/orgInviteRestrict",
+            "in": "query",
+            "description": "An email address with optional wildcard characters. (E.g. `subdomain.*.trello.com`)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "prefs/permissionLevel",
+            "in": "query",
+            "description": "Whether the Workspace page is publicly visible. One of: `private`, `public`",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete an Organization",
+        "description": "Delete an Organization",
+        "operationId": "delete-organizations-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get field on Organization",
+        "description": "",
+        "operationId": "get-organizations-id-field",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "An organization [field](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/OrganizationFields" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/actions": {
+      "get": {
+        "tags": [],
+        "summary": "Get Actions for Organization",
+        "description": "List the actions on a Workspace",
+        "operationId": "get-organizations-id-actions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Action" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/boards": {
+      "get": {
+        "tags": [],
+        "summary": "Get Boards in an Organization",
+        "description": "List the boards in a Workspace",
+        "operationId": "get-organizations-id-boards",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `open`, `closed`, `members`, `organization`, `public`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": [
+                "all",
+                "open",
+                "closed",
+                "members",
+                "organization",
+                "public"
+              ]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of board [fields](/cloud/trello/guides/rest-api/object-definitions/)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "$ref": "#/components/schemas/BoardFields"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Board" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/exports": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or name of the Workspace",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "post": {
+        "tags": [],
+        "summary": "Create Export for Organizations",
+        "description": "Kick off CSV export for an organization",
+        "operationId": "post-organizations-id-exports",
+        "parameters": [
+          {
+            "name": "attachments",
+            "in": "query",
+            "description": "Whether the CSV should include attachments or not.",
+            "required": false,
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Export" }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [],
+        "summary": "Retrieve Organization's Exports",
+        "description": "Retrieve the exports that exist for the given organization",
+        "operationId": "get-organizations-id-exports",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Export" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/members": {
+      "get": {
+        "tags": [],
+        "summary": "Get the Members of an Organization",
+        "description": "List the members in a Workspace",
+        "operationId": "get-organizations-id-members",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the Organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update an Organization's Members",
+        "description": "",
+        "operationId": "put-organizations-id-members",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "An email address",
+            "required": true,
+            "schema": { "type": "string", "format": "email" }
+          },
+          {
+            "name": "fullName",
+            "in": "query",
+            "description": "Name for the member, at least 1 character not beginning or ending with a space",
+            "required": true,
+            "schema": { "type": "string", "minLength": 1 }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "One of: `admin`, `normal`",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "normal",
+              "enum": ["admin", "normal"]
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/memberships": {
+      "get": {
+        "tags": [],
+        "summary": "Get Memberships of an Organization",
+        "description": "List the memberships of a Workspace",
+        "operationId": "get-organizations-id-memberships",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "`all` or a comma-separated list of: `active`, `admin`, `deactivated`, `me`, `normal`",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": ["all", "active", "admin", "deactivated", "me", "normal"]
+            }
+          },
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Whether to include the Member objects with the Memberships",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/Memberships" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/memberships/{idMembership}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Membership of an Organization",
+        "description": "Get a single Membership for an Organization",
+        "operationId": "get-organizations-id-memberships-idmembership",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMembership",
+            "in": "path",
+            "description": "The ID of the membership to load",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "member",
+            "in": "query",
+            "description": "Whether to include the Member object in the response",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Memberships" }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/pluginData": {
+      "get": {
+        "tags": [],
+        "summary": "Get the pluginData Scoped to Organization",
+        "description": "Get organization scoped pluginData on this Workspace",
+        "operationId": "get-organizations-id-plugindata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [{ "$ref": "#/components/schemas/PluginData" }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/tags": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID or name of the Organization",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              { "type": "string" },
+              { "$ref": "#/components/schemas/TrelloID" }
+            ]
+          }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Tags of an Organization",
+        "description": "List the organization's collections",
+        "operationId": "get-organizations-id-tags",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "oneOf": [{ "$ref": "#/components/schemas/Tag" }] }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create a Tag in Organization",
+        "description": "Create a Tag in an Organization",
+        "operationId": "post-organizations-id-tags",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "oneOf": [{ "$ref": "#/components/schemas/Tag" }] }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/members/{idMember}": {
+      "put": {
+        "tags": [],
+        "summary": "Update a Member of an Organization",
+        "description": "Add a member to a Workspace or update their member type.",
+        "operationId": "put-organizations-id-members-idmember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID or username of the member to update",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "#/components/schemas/TrelloID" }
+              ]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "One of: `admin`, `normal`",
+            "required": true,
+            "schema": { "type": "string", "enum": ["admin", "normal"] }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Member" }]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Member from an Organization",
+        "description": "Remove a member from a Workspace",
+        "operationId": "delete-organizations-id-members",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TrelloID" },
+                { "type": "string", "description": "Name of the organization" }
+              ]
+            }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID of the Member to remove from the Workspace",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/members/{idMember}/deactivated": {
+      "put": {
+        "tags": [],
+        "summary": "Deactivate or reactivate a member of an Organization",
+        "description": "Deactivate or reactivate a member of a Workspace",
+        "operationId": "put-organizations-id-members-idmember-deactivated",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID or username of the member to update",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/TrelloID" },
+                { "type": "string" }
+              ]
+            }
+          },
+          {
+            "name": "value",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/logo": {
+      "post": {
+        "tags": [],
+        "summary": "Update logo for an Organization",
+        "description": "Set the logo image for a Workspace",
+        "operationId": "post-organizations-id-logo",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the Workspace",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "file",
+            "in": "query",
+            "description": "Image file for the logo",
+            "required": false,
+            "schema": { "type": "string", "format": "binary" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [{ "$ref": "#/components/schemas/Organization" }]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete Logo for Organization",
+        "description": "Delete a the logo from a Workspace",
+        "operationId": "delete-organizations-id-logo",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/members/{idMember}/all": {
+      "delete": {
+        "tags": [],
+        "summary": "Remove a Member from an Organization and all Organization Boards",
+        "description": "Remove a member from a Workspace and from all Workspace boards",
+        "operationId": "organizations-id-members-idmember-all",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idMember",
+            "in": "path",
+            "description": "The ID of the member to remove from the Workspace",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/prefs/associatedDomain": {
+      "delete": {
+        "tags": [],
+        "summary": "Remove the associated Google Apps domain from a Workspace",
+        "description": "Remove the associated Google Apps domain from a Workspace",
+        "operationId": "delete-organizations-id-prefs-associateddomain",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/prefs/orgInviteRestrict": {
+      "delete": {
+        "tags": [],
+        "summary": "Delete the email domain restriction on who can be invited to the Workspace",
+        "description": "Remove the email domain restriction on who can be invited to the Workspace",
+        "operationId": "delete-organizations-id-prefs-orginviterestrict",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/tags/{idTag}": {
+      "delete": {
+        "tags": [],
+        "summary": "Delete an Organization's Tag",
+        "description": "Delete an organization's tag",
+        "operationId": "delete-organizations-id-tags-idtag",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idTag",
+            "in": "path",
+            "description": "The ID of the tag to delete",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/organizations/{id}/newBillableGuests/{idBoard}": {
+      "get": {
+        "tags": [],
+        "summary": "Get Organizations new billable guests",
+        "description": "Used to check whether the given board has new billable guests on it.",
+        "operationId": "get-organizations-id-newbillableguests-idboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idBoard",
+            "in": "path",
+            "description": "The ID of the board to check for new billable guests.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/plugins/{id}/": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Plugin",
+        "description": "Get plugins",
+        "operationId": "get-plugins-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Plugin" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Plugin",
+        "description": "Update a Plugin",
+        "operationId": "put-plugins-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID or name of the organization",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Plugin" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plugins/{idPlugin}/listing": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Listing for Plugin",
+        "description": "Create a new listing for a given locale for your Power-Up",
+        "operationId": "post-plugins-idplugin-listing",
+        "parameters": [
+          {
+            "name": "idPlugin",
+            "in": "path",
+            "description": "The ID of the Power-Up for which you are creating a new listing.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "The description to show for the given locale"
+                  },
+                  "locale": {
+                    "type": "string",
+                    "description": "The locale that this listing should be displayed for."
+                  },
+                  "overview": {
+                    "type": "string",
+                    "description": "The overview to show for the given locale."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name to use for the given locale."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PluginListing" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plugins/{id}/compliance/memberPrivacy": {
+      "get": {
+        "tags": [],
+        "summary": "Get Plugin's Member privacy compliance",
+        "description": "",
+        "operationId": "get-plugins-id-compliance-memberprivacy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the Power-Up",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/plugins/{idPlugin}/listings/{idListing}": {
+      "put": {
+        "tags": [],
+        "summary": "Updating Plugin's Listing",
+        "description": "Update an existing listing for your Power-Up",
+        "operationId": "put-plugins-idplugin-listings-idlisting",
+        "parameters": [
+          {
+            "name": "idPlugin",
+            "in": "path",
+            "description": "The ID of the Power-Up whose listing is being updated.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idListing",
+            "in": "path",
+            "description": "The ID of the existing listing for the Power-Up that is being updated.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "The description to show for the given locale"
+                  },
+                  "locale": {
+                    "type": "string",
+                    "description": "The locale that this listing should be displayed for."
+                  },
+                  "overview": {
+                    "type": "string",
+                    "description": "The overview to show for the given locale."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name to use for the given locale."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PluginListing" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search": {
+      "get": {
+        "tags": [],
+        "summary": "Search Trello",
+        "description": "Find what you're looking for in Trello",
+        "operationId": "get-search",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The search query with a length of 1 to 16384 characters",
+            "required": true,
+            "schema": { "type": "string", "maxLength": 16834, "minLength": 1 }
+          },
+          {
+            "name": "idBoards",
+            "in": "query",
+            "description": "`mine` or a comma-separated list of Board IDs",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "oneOf": [
+                { "type": "string", "enum": ["mine"] },
+                { "$ref": "#/components/schemas/TrelloID" }
+              ]
+            }
+          },
+          {
+            "name": "idOrganizations",
+            "in": "query",
+            "description": "A comma-separated list of Organization IDs",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "idCards",
+            "in": "query",
+            "description": "A comma-separated list of Card IDs",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "modelTypes",
+            "in": "query",
+            "description": "What type or types of Trello objects you want to search. all or a comma-separated list of: `actions`, `boards`, `cards`, `members`, `organizations`",
+            "required": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "board_fields",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "description": "all or a comma-separated list of: `closed`, `dateLastActivity`, `dateLastView`, `desc`, `descData`, `idOrganization`, `invitations`, `invited`, `labelNames`, `memberships`, `name`, `pinned`, `powerUps`, `prefs`, `shortLink`, `shortUrl`, `starred`, `subscribed`, `url`",
+            "required": false,
+            "schema": { "type": "string", "default": "name,idOrganization" }
+          },
+          {
+            "name": "boards_limit",
+            "in": "query",
+            "description": "The maximum number of boards returned. Maximum: 1000",
+            "required": false,
+            "schema": { "type": "integer", "maximum": 1000, "default": 10 }
+          },
+          {
+            "name": "board_organization",
+            "in": "query",
+            "description": "Whether to include the parent organization with board results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_fields",
+            "in": "query",
+            "description": "all or a comma-separated list of: `badges`, `checkItemStates`, `closed`, `dateLastActivity`, `desc`, `descData`, `due`, `email`, `idAttachmentCover`, `idBoard`, `idChecklists`, `idLabels`, `idList`, `idMembers`, `idMembersVoted`, `idShort`, `labels`, `manualCoverAttachment`, `name`, `pos`, `shortLink`, `shortUrl`, `subscribed`, `url`",
+            "required": false,
+            "style": "form",
+            "explode": false,
+            "schema": { "type": "string", "default": "all" }
+          },
+          {
+            "name": "cards_limit",
+            "in": "query",
+            "description": "The maximum number of cards to return. Maximum: 1000",
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "schema": { "type": "integer", "maximum": 1000, "default": 10 }
+          },
+          {
+            "name": "cards_page",
+            "in": "query",
+            "description": "The page of results for cards. Maximum: 100",
+            "required": false,
+            "schema": { "type": "number", "maximum": 100, "default": 0 }
+          },
+          {
+            "name": "card_board",
+            "in": "query",
+            "description": "Whether to include the parent board with card results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_list",
+            "in": "query",
+            "description": "Whether to include the parent list with card results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_members",
+            "in": "query",
+            "description": "Whether to include member objects with card results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_stickers",
+            "in": "query",
+            "description": "Whether to include sticker objects with card results",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          },
+          {
+            "name": "card_attachments",
+            "in": "query",
+            "description": "Whether to include attachment objects with card results. A boolean value (true or false) or cover for only card cover attachments.",
+            "required": false,
+            "schema": { "type": "string", "default": "false" }
+          },
+          {
+            "name": "organization_fields",
+            "in": "query",
+            "description": "all or a comma-separated list of billableMemberCount, desc, descData, displayName, idBoards, invitations, invited, logoHash, memberships, name, powerUps, prefs, premiumFeatures, products, url, website",
+            "required": false,
+            "schema": { "type": "string", "default": "name,displayName" }
+          },
+          {
+            "name": "organizations_limit",
+            "in": "query",
+            "description": "The maximum number of Workspaces to return. Maximum 1000",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "10" }
+          },
+          {
+            "name": "member_fields",
+            "in": "query",
+            "description": "all or a comma-separated list of: avatarHash, bio, bioData, confirmed, fullName, idPremOrgsAdmin, initials, memberType, products, status, url, username",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "avatarHash,fullName,initials,username,confirmed"
+            }
+          },
+          {
+            "name": "members_limit",
+            "in": "query",
+            "description": "The maximum number of members to return. Maximum 1000",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32", "default": "10" }
+          },
+          {
+            "name": "partial",
+            "in": "query",
+            "description": "By default, Trello searches for each word in your query against exactly matching words within Member content. Specifying partial to be true means that we will look for content that starts with any of the words in your query.  If you are looking for a Card titled \"My Development Status Report\", by default you would need to search for \"Development\". If you have partial enabled, you will be able to search for \"dev\" but not \"velopment\".",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/Member" },
+                      { "$ref": "#/components/schemas/Card" },
+                      { "$ref": "#/components/schemas/Board" },
+                      { "$ref": "#/components/schemas/Organization" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/members/": {
+      "get": {
+        "tags": [],
+        "summary": "Search for Members",
+        "description": "Search for Trello members.",
+        "operationId": "get-search-members",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Search query 1 to 16384 characters long",
+            "required": true,
+            "schema": { "type": "string", "maxLength": 16394, "minLength": 1 }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of results to return. Maximum of 20.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 8,
+              "maximum": 20
+            }
+          },
+          {
+            "name": "idBoard",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "idOrganization",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "onlyOrgMembers",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Member" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tokens/{token}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a Token",
+        "description": "Retrieve information about a token.",
+        "operationId": "get-tokens-token",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of `dateCreated`, `dateExpires`, `idMember`, `identifier`, `permissions`",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TokenFields",
+              "default": "all"
+            }
+          },
+          {
+            "name": "webhooks",
+            "in": "query",
+            "description": "Determines whether to include webhooks.",
+            "required": false,
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Token" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tokens/{token}/member": {
+      "get": {
+        "tags": [],
+        "summary": "Get Token's Member",
+        "description": "Retrieve information about a token's owner by token.",
+        "operationId": "get-tokens-token-member",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "`all` or a comma-separated list of valid fields for [Member Object](/cloud/trello/guides/rest-api/object-definitions/).",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MemberFields",
+              "default": "all"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tokens/{token}/webhooks": {
+      "parameters": [
+        {
+          "name": "token",
+          "in": "path",
+          "description": "",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get Webhooks for Token",
+        "description": "Retrieve all webhooks created with a Token.",
+        "operationId": "get-tokens-token-webhooks",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Webhook" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Create Webhooks for Token",
+        "description": "Create a new webhook for a Token.",
+        "operationId": "post-tokens-token-webhooks",
+        "parameters": [
+          {
+            "name": "description",
+            "in": "query",
+            "description": "A description to be displayed when retrieving information about the webhook.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "description": "The URL that the webhook should POST information to.",
+            "required": true,
+            "schema": { "type": "string", "format": "url" }
+          },
+          {
+            "name": "idModel",
+            "in": "query",
+            "description": "ID of the object to create a webhook on.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Webhook" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tokens/{token}/webhooks/{idWebhook}": {
+      "parameters": [
+        {
+          "name": "token",
+          "in": "path",
+          "description": "",
+          "required": true,
+          "schema": { "type": "string" }
+        },
+        {
+          "name": "idWebhook",
+          "in": "path",
+          "description": "ID of the [Webhooks](ref:webhooks) to retrieve.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Webhook belonging to a Token",
+        "description": "Retrieve a webhook created with a Token.",
+        "operationId": "get-tokens-token-webhooks-idwebhook",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Webhook" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Webhook created by Token",
+        "description": "Delete a webhook created with given token.",
+        "operationId": "delete-tokens-token-webhooks-idwebhook",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Webhook created by Token",
+        "description": "Update a Webhook created by Token",
+        "operationId": "tokenstokenwebhooks-1",
+        "parameters": [
+          {
+            "name": "description",
+            "in": "query",
+            "description": "A description to be displayed when retrieving information about the webhook.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "description": "The URL that the webhook should `POST` information to.",
+            "required": false,
+            "schema": { "type": "string", "format": "url" }
+          },
+          {
+            "name": "idModel",
+            "in": "query",
+            "description": "ID of the object that the webhook is on.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/tokens/{token}/": {
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Token",
+        "description": "Delete a token.",
+        "operationId": "delete-token",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/webhooks/": {
+      "post": {
+        "tags": [],
+        "summary": "Create a Webhook",
+        "description": "Create a new webhook.",
+        "operationId": "post-webhooks",
+        "parameters": [
+          {
+            "name": "description",
+            "in": "query",
+            "description": "A string with a length from `0` to `16384`.",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 16384, "minLength": 0 }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "description": "A valid URL that is reachable with a `HEAD` and `POST` request.",
+            "required": true,
+            "schema": { "type": "string", "format": "url" }
+          },
+          {
+            "name": "idModel",
+            "in": "query",
+            "description": "ID of the model to be monitored",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "active",
+            "in": "query",
+            "description": "Determines whether the webhook is active and sending `POST` requests.",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Webhook" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the webhook to retrieve.",
+          "required": true,
+          "schema": { "$ref": "#/components/schemas/TrelloID" }
+        }
+      ],
+      "get": {
+        "tags": [],
+        "summary": "Get a Webhook",
+        "description": "Get a webhook by ID. You must use the token query parameter and pass in the token the webhook was created under, or else you will encounter a 'webhook does not belong to token' error.",
+        "operationId": "get-webhooks-id",
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Webhook" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [],
+        "summary": "Update a Webhook",
+        "description": "Update a webhook by ID.",
+        "operationId": "put-webhooks-id",
+        "parameters": [
+          {
+            "name": "description",
+            "in": "query",
+            "description": "A string with a length from `0` to `16384`.",
+            "required": false,
+            "schema": { "type": "string", "maxLength": 16384, "minLength": 0 }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "description": "A valid URL that is reachable with a `HEAD` and `POST` request.",
+            "required": false,
+            "schema": { "type": "string", "format": "url" }
+          },
+          {
+            "name": "idModel",
+            "in": "query",
+            "description": "ID of the model to be monitored",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "active",
+            "in": "query",
+            "description": "Determines whether the webhook is active and sending `POST` requests.",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "deprecated": false,
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Webhook" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete a Webhook",
+        "description": "Delete a webhook by ID.",
+        "operationId": "delete-webhooks-id",
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    },
+    "/webhooks/{id}/{field}": {
+      "get": {
+        "tags": [],
+        "summary": "Get a field on a Webhook",
+        "description": "Get a field on a Webhook",
+        "operationId": "webhooksidfield",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the webhook.",
+            "required": true,
+            "schema": { "$ref": "#/components/schemas/TrelloID" }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "description": "Field to retrieve. One of: `active`, `callbackURL`, `description`, `idModel`",
+            "required": true,
+            "schema": {
+              "enum": [
+                "active",
+                "callbackURL",
+                "description",
+                "idModel",
+                "consecutiveFailures",
+                "firstConsecutiveFailDate"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "deprecated": false,
+        "responses": { "200": { "description": "Success" } }
+      }
+    }
+  }
+}

--- a/packages/openapi-to-graphql/test/petstore31.test.ts
+++ b/packages/openapi-to-graphql/test/petstore31.test.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: openapi-to-graphql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict'
+
+import { beforeAll, expect, test } from '@jest/globals'
+import { GraphQLObjectType, GraphQLSchema } from 'graphql'
+
+import * as openAPIToGraphQL from '../src/index'
+
+// Set up the schema first
+const oas = require('./fixtures/petstore31.json')
+
+let createdSchema: GraphQLSchema
+beforeAll(() => {
+  return openAPIToGraphQL
+    .createGraphQLSchema(oas, {
+      softValidation: true
+    })
+    .then(({ schema, report }) => {
+      createdSchema = schema
+    })
+    .catch((e) => {
+      console.log(e)
+    })
+})
+
+test('Petstore 3.1 works', () => {
+  const gqlTypes = Object.keys(
+    (createdSchema.getTypeMap().Query as GraphQLObjectType).getFields()
+  )
+  expect(gqlTypes).toEqual(2)
+})

--- a/packages/openapi-to-graphql/test/trello.test.ts
+++ b/packages/openapi-to-graphql/test/trello.test.ts
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: openapi-to-graphql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict'
+
+import { beforeAll, expect, test } from '@jest/globals'
+import { GraphQLObjectType, GraphQLSchema, printSchema } from 'graphql'
+
+import * as openAPIToGraphQL from '../src/index'
+
+// Set up the schema first
+const oas = require('./fixtures/trello.json')
+
+let createdSchema: GraphQLSchema
+beforeAll(() => {
+  return openAPIToGraphQL
+    .createGraphQLSchema(oas, {
+      softValidation: true
+    })
+    .then(({ schema, report }) => {
+      createdSchema = schema
+    })
+    .catch((e) => {
+      console.log(e)
+    })
+})
+
+test('Trello API works', () => {
+  const gqlTypes = Object.keys(
+    (
+      (createdSchema.getTypeMap().Query as GraphQLObjectType).getFields()
+        .viewerAnyAuth.type as GraphQLObjectType
+    ).getFields()
+  ).length
+  expect(gqlTypes).toEqual(82)
+})


### PR DESCRIPTION
## Soft Validation

OpenAPI-to-GraphQL will by default validate the given OAS before creating a GraphQL schema. If the `softValidation` mode is enabled, however, `createGraphQLSchema` will not validate the given OAS before creating a GraphQL schema. This is useful if you want to create a GraphQL schema for an OAS that is not fully compliant with the OpenAPI Specification. Errors will be added to the report object.

## Support for 3.1 spec

We changed the library that performs validation to a new one that supports 3.1. We implemented few changes to the implementation to support [differences between 3.0 and 3.1](https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0)